### PR TITLE
Fix expand tree button with select rows

### DIFF
--- a/packages/components/src/components/common/table/edit/edit.tsx
+++ b/packages/components/src/components/common/table/edit/edit.tsx
@@ -1,4 +1,4 @@
-import { Input, type InputProps, SimpleSelect, type SimpleSelectProps } from '@/components';
+import { Input, type InputProps, BasicSelect, type BasicSelectProps } from '@/components';
 import type { CellContext, RowData } from '@tanstack/react-table';
 import * as React from 'react';
 import { editCell } from './edit.css';
@@ -36,13 +36,13 @@ const InputCell = <TData,>({ cell, className, ...props }: InputCellProps<TData>)
 };
 InputCell.displayName = 'InputCell';
 
-type SelectCellProps<TData> = SimpleSelectProps & {
+type SelectCellProps<TData> = BasicSelectProps & {
   cell: CellContext<TData, string>;
 };
 
 const SelectCell = <TData,>({ cell, className, ...props }: SelectCellProps<TData>) => {
   const { value, updateValue, className: editCell } = useEditCell(cell);
-  return <SimpleSelect value={value} onValueChange={updateValue} className={cn(editCell, className)} {...props} />;
+  return <BasicSelect value={value} onValueChange={updateValue} className={cn(editCell, className)} {...props} />;
 };
 SelectCell.displayName = 'SelectCell';
 

--- a/packages/components/src/components/common/table/table.css.ts
+++ b/packages/components/src/components/common/table/table.css.ts
@@ -1,5 +1,4 @@
 import { vars } from '@/styles/theme.css';
-import { transitionColors } from '@/styles/transition.css';
 import { style } from '@vanilla-extract/css';
 
 export const root = style({
@@ -36,15 +35,12 @@ export const footer = style({
   backgroundColor: vars.color.n100
 });
 
-export const row = style([
-  transitionColors,
-  {
-    borderBottom: vars.border.basic,
-    ':last-child': {
-      borderBottom: 'none'
-    }
+export const row = style({
+  borderBottom: vars.border.basic,
+  ':last-child': {
+    borderBottom: 'none'
   }
-]);
+});
 
 export const head = style({
   height: 20,

--- a/packages/components/src/components/common/table/tree/tree.tsx
+++ b/packages/components/src/components/common/table/tree/tree.tsx
@@ -21,7 +21,10 @@ const expanedButton = <TData,>(row: Row<TData>, lazy?: LazyExpand<TData>) => {
         className={expandButton}
         aria-label={row.getIsExpanded() ? 'Collapse row' : 'Expand row'}
         data-state={row.getIsExpanded() ? 'expanded' : 'collapsed'}
-        onClick={row.getToggleExpandedHandler()}
+        onMouseDown={row.getToggleExpandedHandler()}
+        onKeyDown={e => {
+          if (e.key === 'Enter' || e.key === ' ') row.getToggleExpandedHandler()();
+        }}
       />
     );
   }


### PR DESCRIPTION
Before (first only changes selection of row, second will trigger the collapse/expand):
![Screen Recording 2024-06-11 at 08 15 36](https://github.com/axonivy/ui-components/assets/42733123/4af8d15c-6c33-4272-a6d4-95a0b8e0b3b9)


After fix (expand will no longer trigger the selection):
![Screen Recording 2024-06-11 at 08 12 18](https://github.com/axonivy/ui-components/assets/42733123/77243134-d85f-4a9e-82a4-f22fd2ed65c4)

IMO good behavior and anyway better that the the collapse/expand only trigger on the second click. Maybe you don't want to change the selection with a click on the expand button...
