### PR TITLE
XIVY-14003 fix indentation in tree

### DIFF
--- a/packages/components/src/components/common/table/tree/data.ts
+++ b/packages/components/src/components/common/table/tree/data.ts
@@ -7,6 +7,11 @@ export interface Variable {
 
 export const treeData: Array<Variable> = [
   {
+    name: 'rootScalar',
+    value: 'value',
+    children: []
+  },
+  {
     name: 'param.procurementRequest',
     value: '',
     children: [

--- a/packages/components/src/components/common/table/tree/tree.tsx
+++ b/packages/components/src/components/common/table/tree/tree.tsx
@@ -43,7 +43,7 @@ const indent = <TData,>(row: Row<TData>, icon?: IvyIcons, lazy?: LazyExpand<TDat
   if (row.getCanExpand() || (lazy && lazy.isLoaded === false)) {
     return indent;
   }
-  const base = row.depth > 0 && icon ? 24 : 0;
+  const base = icon ? 24 : 0;
   return base + indent;
 };
 


### PR DESCRIPTION
On root level, icons are not aligned if some of the entries are collapsible, while they are aligned once the depth is bigger than 0. I think it should look the same in both cases. Thoughts?

Before:
![image](https://github.com/axonivy/ui-components/assets/141232142/4c418b28-8db5-4588-9644-d1c0c6bb2d52)

After:
![image](https://github.com/axonivy/ui-components/assets/141232142/bc839fe6-bfdc-40b2-a951-6be1d553f84f)
