### PR TITLE
XIVY-14003 adjust icon sizes

### DIFF
--- a/packages/components/src/components/common/table/tree/tree.css.ts
+++ b/packages/components/src/components/common/table/tree/tree.css.ts
@@ -8,3 +8,7 @@ export const expandButton = style({
     }
   }
 });
+
+export const cellIcon = style({
+  fontSize: '16px'
+});

--- a/packages/components/src/components/common/table/tree/tree.tsx
+++ b/packages/components/src/components/common/table/tree/tree.tsx
@@ -2,7 +2,7 @@ import type * as React from 'react';
 import { Button, Flex, IvyIcon } from '@/components';
 import { IvyIcons } from '@axonivy/ui-icons';
 import type { CellContext, Row } from '@tanstack/react-table';
-import { expandButton } from './tree.css';
+import { cellIcon, expandButton } from './tree.css';
 
 type LazyExpand<TData> = { isLoaded: boolean; loadChildren: (row: Row<TData>) => void };
 
@@ -50,7 +50,7 @@ const indent = <TData,>(row: Row<TData>, icon?: IvyIcons, lazy?: LazyExpand<TDat
 const ExpandableCell = <TData,>({ cell, icon, lazy, children }: ExpandableCellProps<TData>) => (
   <Flex direction='row' alignItems='center' gap={1} style={{ paddingLeft: `${indent(cell.row, icon, lazy)}px` }}>
     {expanedButton(cell.row, lazy)}
-    {icon && <IvyIcon icon={icon} />}
+    {icon && <IvyIcon icon={icon} className={cellIcon} />}
     {children ? children : <span>{cell.getValue()}</span>}
   </Flex>
 );

--- a/packages/components/src/components/editor/sidebar/header.css.ts
+++ b/packages/components/src/components/editor/sidebar/header.css.ts
@@ -26,7 +26,7 @@ export const headerTitle = style({
 export const headerIcon = style({
   selectors: {
     [`${header} &`]: {
-      fontSize: '1.3rem'
+      fontSize: '16px'
     }
   }
 });


### PR DESCRIPTION
Anaïs said to make all the icons in the variables editor the same size (16px).
I think this should be a global change.
Maybe we should think about streamlining the size of all icons in general to 16px?