### PR TITLE
set icon peerdep version to *

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23592,7 +23592,7 @@
         "vitest": "^1.5.3"
       },
       "peerDependencies": {
-        "@axonivy/ui-icons": "~11.3.2-next",
+        "@axonivy/ui-icons": "*",
         "react": "^18.2.0"
       }
     },

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -31,7 +31,7 @@
     "react-resizable-panels": "^2.0.13"
   },
   "peerDependencies": {
-    "@axonivy/ui-icons": "~11.3.2-next",
+    "@axonivy/ui-icons": "*",
     "react": "^18.2.0"
   },
   "devDependencies": {


### PR DESCRIPTION
I have published this branch, see [11.3.2-next.161](https://npmjs-registry.ivyteam.ch/-/web/detail/@axonivy/ui-components/v/11.3.2-next.161). this change would fix the form and config editor issue https://jenkins.ivyteam.io/job/form-editor-client/job/release%252F11.3/64/console