### PR TITLE
XIVY-13261 Add minWidth to ToolbarContainer

### DIFF
--- a/packages/components/src/components/editor/toolbar/toolbar.css.ts
+++ b/packages/components/src/components/editor/toolbar/toolbar.css.ts
@@ -30,9 +30,17 @@ export const toolbarTitle = style({
   fontSize: '14px'
 });
 
-const createQuery = (width?: number) => ({
+const createMaxWidthQuery = (maxWidth?: number) => ({
   '@container': {
-    [`${container} (width < ${width}px)`]: {
+    [`${container} (width < ${maxWidth}px)`]: {
+      display: 'none'
+    }
+  }
+});
+
+const createMinWidthQuery = (minWidth?: number) => ({
+  '@container': {
+    [`${container} (width > ${minWidth}px)`]: {
       display: 'none'
     }
   }
@@ -40,9 +48,13 @@ const createQuery = (width?: number) => ({
 
 export const toolbarContainer = recipe({
   variants: {
-    width: {
-      450: createQuery(450),
-      650: createQuery(650)
+    maxWidth: {
+      450: createMaxWidthQuery(450),
+      650: createMaxWidthQuery(650)
+    },
+    minWidth: {
+      450: createMinWidthQuery(450),
+      650: createMinWidthQuery(650)
     }
   }
 });

--- a/packages/components/src/components/editor/toolbar/toolbar.stories.tsx
+++ b/packages/components/src/components/editor/toolbar/toolbar.stories.tsx
@@ -29,12 +29,21 @@ export const Default = ({ sideBarCollapse }: { sideBarCollapse?: () => void }) =
         <Button icon={IvyIcons.SelectionTool} size='large' toggle={true} />
         <Button icon={IvyIcons.MultiSelection} size='large' />
       </Flex>
-      <ToolbarContainer width={650}>
+      <ToolbarContainer maxWidth={650}>
         <Flex>
           <Separator orientation='vertical' style={{ height: '26px' }} />
           <Flex gap={1}>
             <Button icon={IvyIcons.Undo} size='large' />
             <Button icon={IvyIcons.Redo} size='large' />
+          </Flex>
+        </Flex>
+      </ToolbarContainer>
+      <ToolbarContainer minWidth={650}>
+        <Flex>
+          <Separator orientation='vertical' style={{ height: '26px' }} />
+          <Flex gap={1}>
+            <Button icon={IvyIcons.DeviceMobile} size='large' />
+            <Button icon={IvyIcons.EventStart} size='large' />
           </Flex>
         </Flex>
       </ToolbarContainer>

--- a/packages/components/src/components/editor/toolbar/toolbar.tsx
+++ b/packages/components/src/components/editor/toolbar/toolbar.tsx
@@ -21,9 +21,9 @@ const ToolbarTitle = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLD
 ToolbarTitle.displayName = 'ToolbarTitle';
 
 const ToolbarContainer = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement> & ToolbarContainerVariants>(
-  ({ width, className, children, ...props }, ref) => {
+  ({ maxWidth, minWidth, className, children, ...props }, ref) => {
     return (
-      <div className={cn(toolbarContainer({ width }), className)} ref={ref} {...props}>
+      <div className={cn(toolbarContainer({ maxWidth, minWidth }), className)} ref={ref} {...props}>
         {children}
       </div>
     );


### PR DESCRIPTION
I have extended the ToolbarContainer component so that I can easily enable a similar responsive behaviour of the toolbar analogous to the process editor. Now it is not only possible to define that parts above a certain width are no longer displayed, but also the opposite, i.e. that parts above a certain width are only displayed.