### PR TITLE
Fix toolbar container queries

### DIFF
--- a/packages/components/src/components/editor/toolbar/toolbar.css.ts
+++ b/packages/components/src/components/editor/toolbar/toolbar.css.ts
@@ -32,7 +32,7 @@ export const toolbarTitle = style({
 
 const createMaxWidthQuery = (maxWidth?: number) => ({
   '@container': {
-    [`${container} (width < ${maxWidth}px)`]: {
+    [`${container} (width <= ${maxWidth}px)`]: {
       display: 'none'
     }
   }


### PR DESCRIPTION
@ivy-edp 
Always make sure that you catch all cases otherwise something like the following can happen:
![image](https://github.com/user-attachments/assets/5ff5b391-fea2-4222-aeeb-f422421dcbd5)
