### PR TITLE
Improve browser component

### DIFF
--- a/packages/components/src/components/common/table/tree/tree.tsx
+++ b/packages/components/src/components/common/table/tree/tree.tsx
@@ -14,6 +14,12 @@ type ExpandableCellProps<TData> = {
 };
 
 const expanedButton = <TData,>(row: Row<TData>, lazy?: LazyExpand<TData>) => {
+  const expandHandlerProps = (handler: () => void) => ({
+    onMouseDown: handler,
+    onKeyDown: (e: React.KeyboardEvent<HTMLButtonElement>) => {
+      if (e.key === 'Enter' || e.key === ' ') handler();
+    }
+  });
   if (row.getCanExpand()) {
     return (
       <Button
@@ -21,10 +27,7 @@ const expanedButton = <TData,>(row: Row<TData>, lazy?: LazyExpand<TData>) => {
         className={expandButton}
         aria-label={row.getIsExpanded() ? 'Collapse row' : 'Expand row'}
         data-state={row.getIsExpanded() ? 'expanded' : 'collapsed'}
-        onMouseDown={row.getToggleExpandedHandler()}
-        onKeyDown={e => {
-          if (e.key === 'Enter' || e.key === ' ') row.getToggleExpandedHandler()();
-        }}
+        {...expandHandlerProps(row.getToggleExpandedHandler())}
       />
     );
   }
@@ -33,7 +36,15 @@ const expanedButton = <TData,>(row: Row<TData>, lazy?: LazyExpand<TData>) => {
       lazy.loadChildren(row);
       row.toggleExpanded(true);
     };
-    return <Button icon={IvyIcons.Chevron} className={expandButton} aria-label='Expand row' onClick={loadLazy} data-state='collapsed' />;
+    return (
+      <Button
+        icon={IvyIcons.Chevron}
+        className={expandButton}
+        aria-label='Expand row'
+        data-state='collapsed'
+        {...expandHandlerProps(loadLazy)}
+      />
+    );
   }
   return null;
 };

--- a/packages/components/src/components/editor/browser/browser.stories.tsx
+++ b/packages/components/src/components/editor/browser/browser.stories.tsx
@@ -1,9 +1,19 @@
 import type { Meta, StoryObj } from '@storybook/react';
 import { BrowsersView, useBrowser } from './browser';
-import { attrData, cmsData, funcData, roleData } from './data';
+import { cmsData, funcData, roleData, useAttrBrowser } from './data';
 import { IvyIcons } from '@axonivy/ui-icons';
 import { CmsInfoProvider, FunctionInfoProvider } from './browser-info-provider';
-import { Button, Dialog, DialogContent, DialogHeader, DialogTitle, DialogTrigger, Input, InputGroup } from '@/components/common';
+import {
+  BasicCheckbox,
+  Button,
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+  Input,
+  InputGroup
+} from '@/components/common';
 import { useState } from 'react';
 
 const meta: Meta<typeof BrowsersView> = {
@@ -17,33 +27,41 @@ type Story = StoryObj<typeof BrowsersView>;
 
 const DefaultBrowser = ({ applyFn }: { applyFn?: (value?: string) => void }) => {
   const roles = useBrowser(roleData);
-  const attrs = useBrowser(attrData);
+  const attrs = useAttrBrowser();
   const funcs = useBrowser(funcData);
   const cms = useBrowser(cmsData);
+
   return (
     <BrowsersView
       browsers={[
-        { name: 'Roles', icon: IvyIcons.Users, browser: roles },
-        { name: 'Attribute', icon: IvyIcons.Attribute, browser: attrs },
+        {
+          name: 'Roles',
+          icon: IvyIcons.Users,
+          browser: roles,
+          header: <BasicCheckbox checked={true} label='You can also render a checkbox here' />
+        },
+        { name: 'Attribute', icon: IvyIcons.Attribute, browser: attrs, header: `Info: Lazy loaded row 'requester (User)'` },
         {
           name: 'Functions',
           icon: IvyIcons.Function,
           browser: funcs,
+          header: 'Info: Lazy loaded info content (1s timeout)',
           infoProvider: row => <FunctionInfoProvider row={row} />,
-          applyModifier: value => ({ cursor: `function: ${value}` })
+          applyModifier: row => ({ value: `function: ${row?.original.value}` })
         },
         {
           name: 'CMS',
           icon: IvyIcons.Cms,
           browser: cms,
+          header: 'Info: More info content (with language details) / value modified with macro tags',
           infoProvider: row => <CmsInfoProvider row={row} />,
-          applyModifier: value => ({ cursor: `<%= ivy.co('${value}') %>` })
+          applyModifier: row => ({ value: `<%= ivy.co('${row?.original.value}') %>` })
         }
       ]}
-      apply={(value, type) => {
-        console.log('apply', value, type);
-        if (applyFn) applyFn(value?.cursor);
-        else if (value) alert(`Browser '${type}' apply: ${value.cursor}`);
+      apply={(browserName, result) => {
+        console.log('apply', browserName, result);
+        if (applyFn) applyFn(result?.value);
+        else if (result) alert(`Browser '${browserName}' apply: ${result.value}`);
       }}
     />
   );

--- a/packages/components/src/components/editor/browser/data.ts
+++ b/packages/components/src/components/editor/browser/data.ts
@@ -1,33 +1,59 @@
 import { IvyIcons } from '@axonivy/ui-icons';
-import type { BrowserNode } from './browser';
+import { useBrowser, type BrowserNode } from './browser';
+import { useState } from 'react';
+import type { Row } from '@tanstack/react-table';
 
-export const attrData: Array<BrowserNode> = [
-  {
-    value: 'param',
-    info: '<>',
-    icon: IvyIcons.Attribute,
-    children: [
-      {
-        value: 'out',
-        info: 'ProcurementRequest',
-        icon: IvyIcons.Attribute,
-        children: [
-          { value: 'accepted', info: 'Boolean', icon: IvyIcons.Attribute, children: [] },
-          {
-            value: 'requester',
-            info: 'User',
-            icon: IvyIcons.Attribute,
-            children: [
-              { value: 'email', info: 'String', icon: IvyIcons.Attribute, children: [] },
-              { value: 'fullName', info: 'String', icon: IvyIcons.Attribute, children: [] },
-              { value: 'role', info: 'String', icon: IvyIcons.Attribute, children: [] }
-            ]
-          }
-        ]
+export const useAttrBrowser = () => {
+  const [attr, setAttr] = useState<Array<BrowserNode>>([
+    {
+      value: 'param',
+      info: '<>',
+      icon: IvyIcons.Attribute,
+      isLoaded: true,
+      children: [
+        {
+          value: 'out',
+          info: 'ProcurementRequest',
+          icon: IvyIcons.Attribute,
+          isLoaded: true,
+          children: [
+            { value: 'accepted', info: 'Boolean', icon: IvyIcons.Attribute, children: [] },
+            {
+              value: 'requester',
+              info: 'User',
+              icon: IvyIcons.Attribute,
+              isLoaded: false,
+              children: []
+            }
+          ]
+        }
+      ]
+    }
+  ]);
+
+  const loadChildrenFor = (tree: Array<BrowserNode>): Array<BrowserNode> => {
+    return tree.map(node => {
+      if (node.isLoaded === false) {
+        node.children = [
+          { value: 'email', info: 'String', icon: IvyIcons.Attribute, children: [] },
+          { value: 'fullName', info: 'String', icon: IvyIcons.Attribute, children: [] },
+          { value: 'role', info: 'String', icon: IvyIcons.Attribute, children: [] }
+        ];
+        node.isLoaded = true;
+      } else {
+        loadChildrenFor(node.children);
       }
-    ]
-  }
-];
+      return node;
+    });
+  };
+
+  const loadLazy = (row: Row<BrowserNode>) => {
+    setAttr(old => loadChildrenFor(old));
+    console.log('lazy load attrs for ', row.original.value);
+  };
+
+  return useBrowser(attr, loadLazy);
+};
 
 export const funcData: Array<BrowserNode> = [
   {


### PR DESCRIPTION
- Support for load more rows lazy
- Add header property for more info or a filter or whatever (imporve story with info what which browser do special)
- Export more Browser types
- Change Browser type `BrowserValue` to `BrowserResult` (with `value` attribute instead of `cursor`)
- Change apply function signature from `(value?: BrowserValue, type?: string) => void` to `(browserName: string, result?: BrowserResult) => void`
- Change applyModifier signature from `(value: string) => BrowserValue` to `(row: Row<BrowserNode>) => BrowserResult`