### PR TITLE
XIVY-12289 return selection after deletion

### DIFF
--- a/packages/components/src/utils/table/table.test.ts
+++ b/packages/components/src/utils/table/table.test.ts
@@ -42,12 +42,13 @@ describe('deleteFirstSelectedRow', () => {
     const { data, table, onRowSelectionChangeValues } = setupTable();
     const originalData = structuredClone(data);
     table.getState().rowSelection = { '1': true };
-    const newData = deleteFirstSelectedRow(table, data);
+    const { newData, selection } = deleteFirstSelectedRow(table, data);
     expect(data).toEqual(originalData);
     expect(newData).not.toBe(data);
     expect(newData).toHaveLength(2);
     expect(newData[0]).toEqual(data[0]);
     expect(newData[1]).toEqual(data[2]);
+    expect(selection).toEqual(1);
     expect(onRowSelectionChangeValues).toEqual([]);
   });
 
@@ -55,12 +56,13 @@ describe('deleteFirstSelectedRow', () => {
     const { data, table, onRowSelectionChangeValues } = setupTable();
     const originalData = structuredClone(data);
     table.getState().rowSelection = { '2': true };
-    const newData = deleteFirstSelectedRow(table, data);
+    const { newData, selection } = deleteFirstSelectedRow(table, data);
     expect(data).toEqual(originalData);
     expect(newData).not.toBe(data);
     expect(newData).toHaveLength(2);
     expect(newData[0]).toEqual(data[0]);
     expect(newData[1]).toEqual(data[1]);
+    expect(selection).toEqual(1);
     expect(onRowSelectionChangeValues).toEqual([{ '1': true }]);
   });
 
@@ -69,10 +71,11 @@ describe('deleteFirstSelectedRow', () => {
     const data = [{ name: 'NameData0', value: 'ValueData0' }];
     const originalData = structuredClone(data);
     table.getState().rowSelection = { '0': true };
-    const newData = deleteFirstSelectedRow(table, data);
+    const { newData, selection } = deleteFirstSelectedRow(table, data);
     expect(data).toEqual(originalData);
     expect(newData).not.toBe(data);
     expect(newData).toHaveLength(0);
+    expect(selection).toBeUndefined();
     expect(onRowSelectionChangeValues).toEqual([{}]);
   });
 
@@ -80,10 +83,11 @@ describe('deleteFirstSelectedRow', () => {
     const { data, table, onRowSelectionChangeValues } = setupTable();
     const originalData = structuredClone(data);
     table.getState().rowSelection = {};
-    const newData = deleteFirstSelectedRow(table, data);
+    const { newData, selection } = deleteFirstSelectedRow(table, data);
     expect(data).toEqual(originalData);
     expect(newData).not.toBe(data);
     expect(newData).toEqual(data);
+    expect(selection).toBeUndefined();
     expect(onRowSelectionChangeValues).toEqual([]);
   });
 });

--- a/packages/components/src/utils/table/table.ts
+++ b/packages/components/src/utils/table/table.ts
@@ -19,17 +19,21 @@ export const deleteFirstSelectedRow = <TData>(table: Table<TData>, data: Array<T
   const newData = structuredClone(data);
   const selectedRow = table.getSelectedRowModel().flatRows[0];
   if (!selectedRow) {
-    return newData;
+    return { newData };
   }
   newData.splice(selectedRow.index, 1);
-  adjustSelectionAfterDeletionOfRow(newData, table, selectedRow);
-  return newData;
+  const selection = adjustSelectionAfterDeletionOfRow(newData, table, selectedRow);
+  return { newData, selection };
 };
 
 const adjustSelectionAfterDeletionOfRow = <TData>(data: Array<TData>, table: Table<TData>, row: Row<TData>) => {
   if (data.length === 0) {
     selectRow(table);
+    return;
   } else if (row.index === data.length) {
-    selectRow(table, String(data.length - 1));
+    const selection = data.length - 1;
+    selectRow(table, String(selection));
+    return selection;
   }
+  return row.index;
 };


### PR DESCRIPTION
When calling `deleteFirstSelectedRow` the selection in the table is changed by using some logic. The value of the new selection is usually needed after calling this function. E.g. in the data class editor, after deleting the selected row, the selected field needs to be set to the same selection in the table. Instead of recalculating this value using the same logic, it will be returned from `deleteFirstSelectedRow`.