### PR TITLE
XIVY-13131 Make row not selectable & add custom expandedState

### DIFF
--- a/packages/components/src/components/editor/browser/browser.test.tsx
+++ b/packages/components/src/components/editor/browser/browser.test.tsx
@@ -45,8 +45,8 @@ test('info provider', async () => {
   await act(async () => await userEvent.click(screen.getByRole('tab', { name: 'Attribute' })));
   expect(screen.getByRole('region')).toHaveTextContent('');
 
-  await act(async () => await userEvent.click(screen.getByRole('row', { name: 'param <>' })));
-  expect(screen.getByRole('region')).toHaveTextContent('param');
+  await act(async () => await userEvent.click(screen.getByRole('row', { name: 'out ProcurementRequest' })));
+  expect(screen.getByRole('region')).toHaveTextContent('out');
 
   await act(async () => await userEvent.click(screen.getByRole('tab', { name: 'Roles' })));
   expect(screen.getByRole('region')).toHaveTextContent('Teamleader');

--- a/packages/components/src/components/editor/browser/data.ts
+++ b/packages/components/src/components/editor/browser/data.ts
@@ -7,9 +7,10 @@ export const useAttrBrowser = () => {
   const [attr, setAttr] = useState<Array<BrowserNode>>([
     {
       value: 'param',
-      info: '<>',
+      info: '<> (not selectable)',
       icon: IvyIcons.Attribute,
       isLoaded: true,
+      notSelectable: true,
       children: [
         {
           value: 'out',


### PR DESCRIPTION
For the Logic Browser, I have implemented the following two functions:
- Control which row is selectable and which is not
- Define a custom expandedState

This is because the Logic Browser always has the same two root nodes, "Methods" and "Events," and these should always be expanded by default and not selectable.