### PR TITLE
XIVY-15138 add useShortcut hook

### DIFF
--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -55,3 +55,4 @@ export * from './utils/string';
 export * from './utils/utils';
 export * from './utils/table/table';
 export * from './utils/table/table-data';
+export * from './utils/useShortcut';

--- a/packages/components/src/utils/useShortcut.test.tsx
+++ b/packages/components/src/utils/useShortcut.test.tsx
@@ -1,0 +1,62 @@
+import { useShortcut } from '@/utils/useShortcut';
+import { fireEvent, render } from '@testing-library/react';
+
+type TestComponentProps = {
+  shortcutKey: string;
+  callback: () => void;
+  modifiers?: { ctrl?: boolean; alt?: boolean; shift?: boolean };
+};
+
+const TestComponent = ({ shortcutKey: key, callback, modifiers }: TestComponentProps) => {
+  useShortcut(key, callback, modifiers);
+  return <div>Test Component</div>;
+};
+
+test('default', () => {
+  let shortcutTriggered = false;
+  render(<TestComponent shortcutKey={'a'} callback={() => (shortcutTriggered = true)} />);
+
+  fireEvent.keyDown(document, { key: 'a', ctrlKey: true, shiftKey: true });
+  expect(shortcutTriggered).toBeFalsy();
+
+  fireEvent.keyDown(document, { key: 'a', altKey: true, shiftKey: true });
+  expect(shortcutTriggered).toBeFalsy();
+
+  fireEvent.keyDown(document, { key: 'z', ctrlKey: true, altKey: true });
+  expect(shortcutTriggered).toBeFalsy();
+
+  fireEvent.keyDown(document, { key: 'a', ctrlKey: true, altKey: true });
+  expect(shortcutTriggered).toBeTruthy();
+});
+
+test('custom', () => {
+  let shortcutTriggered = false;
+  render(<TestComponent shortcutKey={'a'} callback={() => (shortcutTriggered = true)} modifiers={{ shift: true }} />);
+
+  fireEvent.keyDown(document, { key: 'a', ctrlKey: true });
+  expect(shortcutTriggered).toBeFalsy();
+
+  fireEvent.keyDown(document, { key: 'a', altKey: true });
+  expect(shortcutTriggered).toBeFalsy();
+
+  fireEvent.keyDown(document, { key: 'z', shiftKey: true });
+  expect(shortcutTriggered).toBeFalsy();
+
+  fireEvent.keyDown(document, { key: 'a', shiftKey: true });
+  expect(shortcutTriggered).toBeTruthy();
+});
+
+test('mac', () => {
+  Object.defineProperty(window.navigator, 'userAgent', {
+    value: 'Mac'
+  });
+
+  let shortcutTriggered = false;
+  render(<TestComponent shortcutKey={'a'} callback={() => (shortcutTriggered = true)} />);
+
+  fireEvent.keyDown(document, { key: 'a', ctrlKey: true, altKey: true });
+  expect(shortcutTriggered).toBeFalsy();
+
+  fireEvent.keyDown(document, { key: 'a', metaKey: true, altKey: true });
+  expect(shortcutTriggered).toBeTruthy();
+});

--- a/packages/components/src/utils/useShortcut.test.tsx
+++ b/packages/components/src/utils/useShortcut.test.tsx
@@ -1,5 +1,6 @@
 import { useShortcut } from '@/utils/useShortcut';
-import { fireEvent, render } from '@testing-library/react';
+import { render } from '@testing-library/react';
+import { userEvent } from 'test-utils';
 
 type TestComponentProps = {
   shortcutKey: string;
@@ -12,41 +13,41 @@ const TestComponent = ({ shortcutKey: key, callback, modifiers }: TestComponentP
   return <div>Test Component</div>;
 };
 
-test('default', () => {
+test('default', async () => {
   let shortcutTriggered = false;
   render(<TestComponent shortcutKey={'a'} callback={() => (shortcutTriggered = true)} />);
 
-  fireEvent.keyDown(document, { key: 'a', ctrlKey: true, shiftKey: true });
+  await userEvent.keyboard('{Control>}{Shift>}{a}');
   expect(shortcutTriggered).toBeFalsy();
 
-  fireEvent.keyDown(document, { key: 'a', altKey: true, shiftKey: true });
+  await userEvent.keyboard('{Alt>}{Shift>}{a}');
   expect(shortcutTriggered).toBeFalsy();
 
-  fireEvent.keyDown(document, { key: 'z', ctrlKey: true, altKey: true });
+  await userEvent.keyboard('{Control>}{Alt>}{z}');
   expect(shortcutTriggered).toBeFalsy();
 
-  fireEvent.keyDown(document, { key: 'a', ctrlKey: true, altKey: true });
+  await userEvent.keyboard('{Control>}{Alt>}{a}');
   expect(shortcutTriggered).toBeTruthy();
 });
 
-test('custom', () => {
+test('custom', async () => {
   let shortcutTriggered = false;
   render(<TestComponent shortcutKey={'a'} callback={() => (shortcutTriggered = true)} modifiers={{ shift: true }} />);
 
-  fireEvent.keyDown(document, { key: 'a', ctrlKey: true });
+  await userEvent.keyboard('{Control>}{a}');
   expect(shortcutTriggered).toBeFalsy();
 
-  fireEvent.keyDown(document, { key: 'a', altKey: true });
+  await userEvent.keyboard('{Alt>}{a}');
   expect(shortcutTriggered).toBeFalsy();
 
-  fireEvent.keyDown(document, { key: 'z', shiftKey: true });
+  await userEvent.keyboard('{Shift>}{z}');
   expect(shortcutTriggered).toBeFalsy();
 
-  fireEvent.keyDown(document, { key: 'a', shiftKey: true });
+  await userEvent.keyboard('{Shift>}{a}');
   expect(shortcutTriggered).toBeTruthy();
 });
 
-test('mac', () => {
+test('mac', async () => {
   Object.defineProperty(window.navigator, 'userAgent', {
     value: 'Mac'
   });
@@ -54,9 +55,9 @@ test('mac', () => {
   let shortcutTriggered = false;
   render(<TestComponent shortcutKey={'a'} callback={() => (shortcutTriggered = true)} />);
 
-  fireEvent.keyDown(document, { key: 'a', ctrlKey: true, altKey: true });
+  await userEvent.keyboard('{Control>}{Alt>}{a}');
   expect(shortcutTriggered).toBeFalsy();
 
-  fireEvent.keyDown(document, { key: 'a', metaKey: true, altKey: true });
+  await userEvent.keyboard('{Meta>}{Alt>}{a}');
   expect(shortcutTriggered).toBeTruthy();
 });

--- a/packages/components/src/utils/useShortcut.ts
+++ b/packages/components/src/utils/useShortcut.ts
@@ -1,0 +1,22 @@
+import { useCallback, useEffect, useLayoutEffect, useRef } from 'react';
+
+export const useShortcut = (key: string, callback: () => void) => {
+  const callbackRef = useRef(callback);
+  useLayoutEffect(() => {
+    callbackRef.current = callback;
+  });
+
+  const handleKeyPress = useCallback(
+    (event: KeyboardEvent) => {
+      if (event.ctrlKey && event.altKey && event.key === key) {
+        callbackRef.current();
+      }
+    },
+    [key]
+  );
+
+  useEffect(() => {
+    document.addEventListener('keydown', handleKeyPress);
+    return () => document.removeEventListener('keydown', handleKeyPress);
+  });
+};

--- a/packages/components/src/utils/useShortcut.ts
+++ b/packages/components/src/utils/useShortcut.ts
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useLayoutEffect, useRef } from 'react';
 
-export const useShortcut = (key: string, callback: () => void) => {
+export const useShortcut = (key: string, callback: () => void, modifiers?: { ctrl?: boolean; alt?: boolean; shift?: boolean }) => {
   const callbackRef = useRef(callback);
   useLayoutEffect(() => {
     callbackRef.current = callback;
@@ -8,15 +8,27 @@ export const useShortcut = (key: string, callback: () => void) => {
 
   const handleKeyPress = useCallback(
     (event: KeyboardEvent) => {
-      if (event.ctrlKey && event.altKey && event.key === key) {
+      const ctrl = modifiers ? modifiers.ctrl : true;
+      const alt = modifiers ? modifiers.alt : true;
+      const shift = modifiers ? modifiers.shift : false;
+
+      const ctrlNotRequiredOrPressed = !ctrl || (isMac() ? event.metaKey : event.ctrlKey);
+      const altNotRequiredOrPressed = !alt || event.altKey;
+      const shiftNotRequiredOrPressed = !shift || event.shiftKey;
+
+      if (ctrlNotRequiredOrPressed && altNotRequiredOrPressed && shiftNotRequiredOrPressed && event.key === key) {
         callbackRef.current();
       }
     },
-    [key]
+    [key, modifiers]
   );
 
   useEffect(() => {
     document.addEventListener('keydown', handleKeyPress);
     return () => document.removeEventListener('keydown', handleKeyPress);
   });
+};
+
+const isMac = () => {
+  return window.navigator.userAgent.indexOf('Mac') !== -1;
 };


### PR DESCRIPTION
I think this is everything needed here since I can solve the `Enter` case with a form.

I'll answer the question from the [other PR](https://github.com/axonivy/dataclass-editor-client/pull/48) about the following code :
```
  const callbackRef = useRef(callback);
  useLayoutEffect(() => {
    callbackRef.current = callback;
  });
```
I got this from [this article](https://www.epicreact.dev/the-latest-ref-pattern-in-react) and in short terms it allows a consumer of this hook to not care about setting up the `callback` function in a `useCallback`. Because we use a reference we do not need to add it to the dependency array of `handleKeyPress`.