### PR TITLE
XIVY-15138 Add Multiselect on ctrl and remove/reorder multiselect

### DIFF
--- a/packages/components/src/components/common/table/footer/footer.stories.tsx
+++ b/packages/components/src/components/common/table/footer/footer.stories.tsx
@@ -9,15 +9,29 @@ import * as React from 'react';
 import { IvyIcons } from '@axonivy/ui-icons';
 import { Button } from '@/components/common/button/button';
 import { BasicField } from '@/components/common/field/field';
+import { deleteAllSelectedRows } from '@/utils/table/table';
 
-const meta: Meta<typeof Table> = {
+interface TableStoryProps {
+  enableMultiselect: boolean;
+}
+
+const meta: Meta<TableStoryProps> = {
   title: 'Common/Table/Footer',
-  component: Table
+  component: AddRemoveTableDemo,
+  argTypes: {
+    enableMultiselect: {
+      control: 'boolean',
+      description: 'Toggle for enabling or disabling multi-select'
+    }
+  },
+  args: {
+    enableMultiselect: false
+  }
 };
 
 export default meta;
 
-type Story = StoryObj<typeof Table>;
+type Story = StoryObj<TableStoryProps>;
 
 const columns: ColumnDef<Payment>[] = [
   {
@@ -48,7 +62,7 @@ const columns: ColumnDef<Payment>[] = [
   }
 ];
 
-function AddRemoveTableDemo() {
+function AddRemoveTableDemo({ enableMultiselect }: { enableMultiselect: boolean }) {
   const [data, setData] = React.useState(tableData);
 
   const addRow = () => {
@@ -58,20 +72,16 @@ function AddRemoveTableDemo() {
   };
 
   const removeRow = () => {
-    const index = table.getRowModel().rowsById[Object.keys(tableSelection.tableState.rowSelection!)[0]].index;
-    const newData = [...data];
-    newData.splice(index, 1);
-    if (newData.length === 0) {
-      tableSelection.options.onRowSelectionChange({});
-    } else if (index === data.length - 1) {
-      tableSelection.options.onRowSelectionChange({ [`${newData.length - 1}`]: true });
-    }
+    const { newData: newFields } = deleteAllSelectedRows(table, data);
+    let newData = structuredClone(data);
+    newData = newFields;
     setData(newData);
   };
 
   const tableSelection = useTableSelect<Payment>();
   const table = useReactTable({
     ...tableSelection.options,
+    enableMultiRowSelection: enableMultiselect,
     data,
     columns,
     getCoreRowModel: getCoreRowModel(),
@@ -113,5 +123,5 @@ function AddRemoveTableDemo() {
 }
 
 export const AddRemove: Story = {
-  render: () => <AddRemoveTableDemo />
+  render: args => <AddRemoveTableDemo enableMultiselect={args.enableMultiselect} />
 };

--- a/packages/components/src/utils/array.ts
+++ b/packages/components/src/utils/array.ts
@@ -20,3 +20,14 @@ export function groupBy<T>(artifacts: T[], resolveKey: (t: T) => string) {
     return { ...prev, [groupKey]: group };
   }, {});
 }
+
+export function arrayMoveMultiple<TArr>(arr: TArr[], fromIndexes: number[], toIndex: number) {
+  const sortedFromIndexes = [...fromIndexes].sort((a, b) => a - b);
+  const elementsToMove = sortedFromIndexes.map(index => arr[index]);
+  for (let i = sortedFromIndexes.length - 1; i >= 0; i--) {
+    arr.splice(sortedFromIndexes[i], 1);
+  }
+  const index = sortedFromIndexes[sortedFromIndexes.length - 1] < toIndex ? toIndex - elementsToMove.length + 1 : toIndex;
+  arr.splice(index, 0, ...elementsToMove);
+  return arr;
+}

--- a/packages/components/src/utils/table/table.test.ts
+++ b/packages/components/src/utils/table/table.test.ts
@@ -48,7 +48,7 @@ describe('deleteFirstSelectedRow', () => {
     expect(newData[0]).toEqual(data[0]);
     expect(newData[1]).toEqual(data[2]);
     expect(selection).toEqual(1);
-    expect(onRowSelectionChangeValues).toEqual([]);
+    expect(onRowSelectionChangeValues).toEqual([{ '1': true }]);
   });
 
   test('lastElementInList', () => {


### PR DESCRIPTION
I will add tests for the new functions in later PR
Multiselect on ctrl with reorder (Table --> Row --> Multi Select With Reorder): https://jenkins.ivyteam.io/job/ui-components/job/add-multiselectTable-reorder-and-remove/3/artifact/packages/components/storybook-static/index.html?path=/story/common-table-row--multi-select-with-reorder
Multiselect with delete (Table --> Footer --> Remove Multiple): https://jenkins.ivyteam.io/job/ui-components/job/add-multiselectTable-reorder-and-remove/3/artifact/packages/components/storybook-static/index.html?path=/story/common-table-footer--remove-multiple