### PR TITLE
XIVY-15045 Add initial selected row to browser

### DIFF
--- a/packages/components/src/components/common/table/hooks/hooks.tsx
+++ b/packages/components/src/components/common/table/hooks/hooks.tsx
@@ -9,7 +9,8 @@ import {
   type TableState,
   getExpandedRowModel,
   type Row,
-  type Table
+  type Table,
+  type RowSelectionState
 } from '@tanstack/react-table';
 import * as React from 'react';
 
@@ -45,8 +46,8 @@ type UseTableSelectRetunValue<TData> = {
   tableState: Partial<TableState>;
 };
 
-export const useTableSelect = <TData,>(): UseTableSelectRetunValue<TData> => {
-  const [rowSelection, setRowSelection] = React.useState({});
+export const useTableSelect = <TData,>(initialSelecteState?: RowSelectionState): UseTableSelectRetunValue<TData> => {
+  const [rowSelection, setRowSelection] = React.useState(initialSelecteState ?? {});
   return {
     options: {
       onRowSelectionChange: setRowSelection,

--- a/packages/components/src/components/editor/browser/browser.stories.tsx
+++ b/packages/components/src/components/editor/browser/browser.stories.tsx
@@ -30,7 +30,7 @@ type DefaultBrowserProps = {
 };
 
 const DefaultBrowser = ({ applyFn, applyBtn, initSearch }: DefaultBrowserProps) => {
-  const roles = useBrowser(roleData, undefined, initSearch);
+  const roles = useBrowser(roleData, { initialSearch: initSearch, initialSelecteState: { '0.1': true } });
   const attrs = useAttrBrowser();
   const funcs = useBrowser(funcData);
   const cms = useBrowser(cmsData);

--- a/packages/components/src/components/editor/browser/browser.test.tsx
+++ b/packages/components/src/components/editor/browser/browser.test.tsx
@@ -35,7 +35,7 @@ test('apply modifier', async () => {
 test('info provider', async () => {
   render(<Browser />);
   await act(async () => await userEvent.click(screen.getByRole('button', { name: 'Info' })));
-  expect(screen.getByRole('region')).toHaveTextContent('');
+  expect(screen.getByRole('region')).toHaveTextContent('Teamleader');
 
   await act(async () => await userEvent.click(screen.getByRole('row', { name: 'Teamleader All teamleaders' })));
   expect(screen.getByRole('region')).toHaveTextContent('Teamleader');

--- a/packages/components/src/components/editor/browser/browser.tsx
+++ b/packages/components/src/components/editor/browser/browser.tsx
@@ -6,7 +6,8 @@ import {
   useReactTable,
   type ColumnDef,
   type ExpandedState,
-  type Row
+  type Row,
+  type RowSelectionState
 } from '@tanstack/react-table';
 import type { IvyIcons } from '@axonivy/ui-icons';
 import { fullHeight, info, overflowAuto, overflowHidden } from './browser.css';
@@ -34,9 +35,12 @@ export type BrowserNode<TData = unknown> = {
 
 export const useBrowser = (
   data: Array<BrowserNode>,
-  loadChildren?: (row: Row<BrowserNode>) => void,
-  initialSearch?: string,
-  expandedState?: ExpandedState
+  options?: {
+    loadChildren?: (row: Row<BrowserNode>) => void;
+    initialSearch?: string;
+    expandedState?: ExpandedState;
+    initialSelecteState?: RowSelectionState;
+  }
 ) => {
   const columns: ColumnDef<BrowserNode, string>[] = [
     {
@@ -46,8 +50,8 @@ export const useBrowser = (
           cell={cell}
           icon={cell.row.original.icon}
           lazy={
-            cell.row.original.isLoaded !== undefined && loadChildren !== undefined
-              ? { isLoaded: cell.row.original.isLoaded, loadChildren }
+            cell.row.original.isLoaded !== undefined && options?.loadChildren !== undefined
+              ? { isLoaded: cell.row.original.isLoaded, loadChildren: options.loadChildren }
               : undefined
           }
         >
@@ -58,9 +62,9 @@ export const useBrowser = (
     }
   ];
 
-  const [filter, setFilter] = React.useState(initialSearch ?? '');
-  const expanded = useTableExpand<BrowserNode>(expandedState ? expandedState : { '0': true });
-  const select = useTableSelect<BrowserNode>();
+  const [filter, setFilter] = React.useState(options?.initialSearch ?? '');
+  const expanded = useTableExpand<BrowserNode>(options?.expandedState ? options.expandedState : { '0': true });
+  const select = useTableSelect<BrowserNode>(options?.initialSelecteState);
   const table = useReactTable({
     ...expanded.options,
     ...select.options,

--- a/packages/components/src/components/editor/browser/data.ts
+++ b/packages/components/src/components/editor/browser/data.ts
@@ -53,7 +53,7 @@ export const useAttrBrowser = () => {
     console.log('lazy load attrs for ', row.original.value);
   };
 
-  return useBrowser(attr, loadLazy);
+  return useBrowser(attr, { loadChildren: loadLazy });
 };
 
 export const funcData: Array<BrowserNode> = [


### PR DESCRIPTION
It should be possible to define whether a row is selected by default. This idea originated from the type browser in the DataClass editor; if a type is already present in the input, it should be selected upon the initial opening of the browser. This will help users better understand their current context within the browser.