### PR TITLE
XIVY-15021 Add TableKeyHandler-Hook

### DIFF
--- a/packages/components/src/components/common/table/table.css.ts
+++ b/packages/components/src/components/common/table/table.css.ts
@@ -16,7 +16,12 @@ export const table = style({
   background: vars.color.n25,
   tableLayout: 'fixed',
   borderCollapse: 'collapse',
-  fontSize: '12px'
+  fontSize: '12px',
+  selectors: {
+    '&:focus-visible': {
+      border: vars.border.active
+    }
+  }
 });
 
 export const header = style({

--- a/packages/components/src/components/common/table/table.tsx
+++ b/packages/components/src/components/common/table/table.tsx
@@ -8,7 +8,7 @@ import { Field } from '@/components/common/field/field';
  */
 const Table = React.forwardRef<HTMLTableElement, React.HTMLAttributes<HTMLTableElement>>(({ className, ...props }, ref) => (
   <Field className={cn(root, 'ui-table-root')}>
-    <table ref={ref} className={cn(table, className, 'ui-table')} {...props} />
+    <table ref={ref} className={cn(table, className, 'ui-table')} tabIndex={0} {...props} />
   </Field>
 ));
 Table.displayName = 'Table';

--- a/packages/components/src/components/common/table/tree/tree.stories.tsx
+++ b/packages/components/src/components/common/table/tree/tree.stories.tsx
@@ -6,8 +6,9 @@ import { treeData, type Variable } from './data';
 import { IvyIcons } from '@axonivy/ui-icons';
 import { useState } from 'react';
 import { ExpandableHeader, TableResizableHeader } from '@/components/common/table/header/header';
-import { useTableExpand, useTableGlobalFilter } from '@/components/common/table/hooks/hooks';
+import { useTableExpand, useTableGlobalFilter, useTableKeyHandler, useTableSelect } from '@/components/common/table/hooks/hooks';
 import { Flex } from '@/components/common/flex/flex';
+import { SelectRow } from '@/components/common/table/row/row';
 
 const meta: Meta<typeof Table> = {
   title: 'Common/Table/Tree',
@@ -192,10 +193,65 @@ export const Search: Story = {
         ...globalFilter.tableState
       }
     });
+
     return (
       <Flex direction='column' gap={1}>
         {globalFilter.filter}
         <TreeTableDemo table={table} />
+      </Flex>
+    );
+  }
+};
+
+export const Select: Story = {
+  render: () => {
+    const columns: ColumnDef<Variable, string>[] = [
+      {
+        accessorKey: 'name',
+        header: header => <ExpandableHeader name='Expand' header={header} />,
+        cell: cell => <ExpandableCell cell={cell} icon={IvyIcons.User} />,
+        minSize: 50
+      },
+      {
+        accessorKey: 'value',
+        header: () => <span>Value</span>,
+        cell: cell => <div>{cell.getValue()}</div>
+      }
+    ];
+
+    const expanded = useTableExpand<Variable>();
+    const globalFilter = useTableGlobalFilter<Variable>();
+    const rowSelection = useTableSelect<Variable>();
+    const table = useReactTable({
+      ...rowSelection.options,
+      ...expanded.options,
+      ...globalFilter.options,
+      data: treeData,
+      columns,
+      getCoreRowModel: getCoreRowModel(),
+      state: {
+        ...expanded.tableState,
+        ...globalFilter.tableState,
+        ...rowSelection.tableState
+      }
+    });
+    const { handleKeyDown } = useTableKeyHandler({ table, data: treeData });
+
+    return (
+      <Flex direction='column' gap={1}>
+        {globalFilter.filter}
+        <Table onKeyDown={handleKeyDown}>
+          <TableResizableHeader headerGroups={table.getHeaderGroups()} />
+          <TableBody>
+            {table.getRowModel().rows.map(row => (
+              <SelectRow key={row.id} row={row}>
+                {row.getVisibleCells().map(cell => (
+                  <TableCell key={cell.id}>{flexRender(cell.column.columnDef.cell, cell.getContext())}</TableCell>
+                ))}
+              </SelectRow>
+            ))}
+          </TableBody>
+        </Table>
       </Flex>
     );
   }

--- a/packages/components/src/components/common/table/tree/tree.tsx
+++ b/packages/components/src/components/common/table/tree/tree.tsx
@@ -29,6 +29,7 @@ const expanedButton = <TData,>(row: Row<TData>, lazy?: LazyExpand<TData>) => {
         className={expandButton}
         aria-label={row.getIsExpanded() ? 'Collapse row' : 'Expand row'}
         data-state={row.getIsExpanded() ? 'expanded' : 'collapsed'}
+        tabIndex={-1}
         {...expandHandlerProps(row.getToggleExpandedHandler())}
       />
     );

--- a/packages/components/src/components/editor/browser/browser.tsx
+++ b/packages/components/src/components/editor/browser/browser.tsx
@@ -17,7 +17,7 @@ import { BasicCollapsible } from '@/components/common/collapsible/collapsible';
 import { Flex } from '@/components/common/flex/flex';
 import { IvyIcon } from '@/components/common/icon/icon';
 import { SearchInput } from '@/components/common/input/input';
-import { useTableExpand, useTableSelect } from '@/components/common/table/hooks/hooks';
+import { useTableExpand, useTableKeyHandler, useTableSelect } from '@/components/common/table/hooks/hooks';
 import { MessageRow, SelectRow } from '@/components/common/table/row/row';
 import { Table, TableBody, TableCell, TableRow } from '@/components/common/table/table';
 import { cn } from '@/utils/class-name';
@@ -80,7 +80,8 @@ export const useBrowser = (
       ...select.tableState
     }
   });
-  return { table, globalFilter: { filter, setFilter } };
+  const { handleKeyDown } = useTableKeyHandler({ table, data, options: { lazyLoadChildren: options?.loadChildren } });
+  return { table, globalFilter: { filter, setFilter }, handleKeyDown };
 };
 
 export type BrowserResult<TData = unknown> = {
@@ -176,7 +177,7 @@ const BrowsersView = ({ browsers, apply, applyBtn }: BrowsersViewProps) => {
                       onChange={browser.globalFilter.setFilter}
                     />
                     <div className={overflowAuto}>
-                      <Table>
+                      <Table onKeyDown={e => browser.handleKeyDown(e, applyHandler)}>
                         <TableBody>
                           {browser.table.getRowModel().rows?.length ? (
                             browser.table.getRowModel().rows.map(row => (


### PR DESCRIPTION
With this new useTableKeyHandler hook, you are able to add the following keyboard functionality to the table:

- Navigate through rows with arrow up/down
- Expand/close Expandable rows with arrow right/left
- Multiselect rows via Shift + Arrow up/down
- Reorder row(s) via Alt + Arrow up/down
- Add a custom Enter functionality to a row (e.g. browser "Apply")

The hook works perfectly with Readonly-Tables, however with editable tables (especially with Tables that have a SelectCell) it does not behave perfectly (see Table --> Edit --> Keyboard Support).
Within Table --> Row / Table --> Tree / BrowserView --> Dialog Browser are example to test it yourself (https://jenkins.ivyteam.io/job/ui-components/job/make-table-keyboard-friendly/11/artifact/packages/components/storybook-static/index.html?path=/)

Something i will do in a later PR are:
- Tests
- (try) Improving hook for Editable-Tables