### PR TITLE
XIVY-15134 treat undefined as empty item in select

### DIFF
--- a/packages/components/src/components/common/select/select.tsx
+++ b/packages/components/src/components/common/select/select.tsx
@@ -138,7 +138,7 @@ const BasicSelect = ({ items, emptyItem, className, placeholder, value, onValueC
       </SelectTrigger>
       <SelectContent>
         <SelectGroup>
-          {emptyItem && value !== '' && <SelectItem value=' '></SelectItem>}
+          {emptyItem && value && <SelectItem value=' '></SelectItem>}
           {unknownValue && <SelectItem value={unknownValue}>{unknownValue}</SelectItem>}
           {items.map(item => (
             <SelectItem key={item.value} value={item.value}>


### PR DESCRIPTION
In the data class editor, I receive undefined for the cardinality of a field with the initial data if it is not set. In this case, the empty item is shown in the select even though nothing seems to be selected. So let's consider undefined when checking whether the empty item is shown by simply checking if the value is truthy.

![empty-item](https://github.com/user-attachments/assets/3ec88aa9-a681-40a4-936c-99437b4f8db8)
