### PR TITLE
Improve useTableKeyHandler-Hook

### DIFF
--- a/packages/components/src/components/common/table/row/row.stories.tsx
+++ b/packages/components/src/components/common/table/row/row.stories.tsx
@@ -258,7 +258,8 @@ export const MultiSelectWithReorder: Story = {
       data,
       options: {
         multiSelect: true,
-        reorder: { updateOrder: updateDataArray, getRowId: row => row.id }
+        reorder: { updateOrder: updateDataArray, getRowId: row => row.id },
+        resetSelectionOnTab: true
       }
     });
 

--- a/packages/components/src/components/common/table/table.css.ts
+++ b/packages/components/src/components/common/table/table.css.ts
@@ -17,10 +17,9 @@ export const table = style({
   tableLayout: 'fixed',
   borderCollapse: 'collapse',
   fontSize: '12px',
-  selectors: {
-    '&:focus-visible': {
-      border: vars.border.active
-    }
+  ':focus-visible': {
+    outline: 'none',
+    border: vars.border.active
   }
 });
 

--- a/packages/components/src/components/editor/browser/data.ts
+++ b/packages/components/src/components/editor/browser/data.ts
@@ -138,7 +138,13 @@ export const cmsData: Array<CmsBrowserNode> = [
         icon: IvyIcons.FolderOpen,
         children: [
           { value: 'accepted', info: 'STRING', icon: IvyIcons.ChangeType, children: [], cmsValues: { de: 'akzeptiert', en: 'accepted' } },
-          { value: 'deslined', info: 'STRING', icon: IvyIcons.ChangeType, children: [], cmsValues: { de: 'abgelehnt', en: 'deslined' } }
+          { value: 'declined', info: 'STRING', icon: IvyIcons.ChangeType, children: [], cmsValues: { de: 'abgelehnt', en: 'declined' } },
+          { value: 'pending', info: 'STRING', icon: IvyIcons.ChangeType, children: [], cmsValues: { de: 'ausstehend', en: 'pending' } },
+          { value: 'processed', info: 'STRING', icon: IvyIcons.ChangeType, children: [], cmsValues: { de: 'bearbeitet', en: 'processed' } },
+          { value: 'rejected', info: 'STRING', icon: IvyIcons.ChangeType, children: [], cmsValues: { de: 'zurück', en: 'rejected' } },
+          { value: 'confirmed', info: 'STRING', icon: IvyIcons.ChangeType, children: [], cmsValues: { de: 'bestätigt', en: 'confirmed' } },
+          { value: 'archived', info: 'STRING', icon: IvyIcons.ChangeType, children: [], cmsValues: { de: 'archiviert', en: 'archived' } },
+          { value: 'draft', info: 'STRING', icon: IvyIcons.ChangeType, children: [], cmsValues: { de: 'Entwurf', en: 'draft' } }
         ],
         cmsValues: {}
       },


### PR DESCRIPTION
While I integrated keyboard support into the other editors, I noticed a few bugs/improvement points. I have addressed them here:
- When a scrollbar is present, the selected row is now always visible (centered).
- The Tab key only resets the selection if specifically defined in the options.
- The ArrowLeft/Right functionality was reversed.