### PR TITLE
XIVY-13545 Impr. TableKeyHandler to work with structuredClone

### DIFF
--- a/packages/components/src/components/common/table/hooks/hooks.tsx
+++ b/packages/components/src/components/common/table/hooks/hooks.tsx
@@ -122,7 +122,7 @@ export const useMultiSelectRow = <TData,>(table: Table<TData>) => {
 
 interface KeyHandlerOptions<TData> {
   multiSelect?: boolean;
-  reorder?: { updateOrder?: (moveIndexes: number[], toIndex: number) => void; getRowId?: (row: TData) => string };
+  reorder?: { updateOrder?: (moveIndexes: number[], toIndex: number, data: TData[]) => void; getRowId?: (row: TData) => string };
   lazyLoadChildren?: (row: Row<TData>) => void;
   resetSelectionOnTab?: boolean;
 }
@@ -168,7 +168,7 @@ export const useTableKeyHandler = <TData,>({ table, data, options }: TableKeyboa
     if (event.altKey && reorder?.updateOrder && reorder.getRowId) {
       const moveIndexes = selectedRows.map(row => row.index);
       const moveIds = selectedRows.map(row => reorder.getRowId!(row.original));
-      reorder.updateOrder(moveIndexes, newReorderIndex);
+      reorder.updateOrder(moveIndexes, newReorderIndex, data);
       resetAndSetRowSelection(table, data, moveIds, reorder.getRowId);
       setRootIndex(newReorderIndex);
     } else if (event.shiftKey && multiSelect) {

--- a/packages/components/src/components/common/table/row/row.stories.tsx
+++ b/packages/components/src/components/common/table/row/row.stories.tsx
@@ -137,14 +137,14 @@ export const Message: Story = {
 export const Reorder: Story = {
   render: () => {
     const [data, setData] = React.useState(tableData);
-    const updateDataArray = (fromIndex: number[], toIndex: number) => {
+    const updateDataArray = (fromIndex: number[], toIndex: number, data: Payment[]) => {
       arraymove(data, fromIndex[0], toIndex);
       setData([...data]);
     };
     const updateOrder = (moveId: string, targetId: string) => {
       const fromIndex = indexOf(data, obj => obj.id === moveId);
       const toIndex = indexOf(data, obj => obj.id === targetId);
-      updateDataArray([fromIndex], toIndex);
+      updateDataArray([fromIndex], toIndex, data);
     };
     const reorderColumns: ColumnDef<Payment>[] = [
       {
@@ -241,7 +241,7 @@ export const MultiSelectWithReorder: Story = {
       }
     });
     const { handleMultiSelectOnRow } = useMultiSelectRow(table);
-    const updateDataArray = (moveIndexes: number[], toIndex: number) => {
+    const updateDataArray = (moveIndexes: number[], toIndex: number, data: Payment[]) => {
       arrayMoveMultiple(data, moveIndexes, toIndex);
       setData([...data]);
     };
@@ -250,8 +250,9 @@ export const MultiSelectWithReorder: Story = {
       const moveIds = selectedRows.length > 1 ? selectedRows : [moveId];
       const moveIndexes = moveIds.map(moveId => indexOf(data, obj => obj.id === moveId));
       const toIndex = indexOf(data, obj => obj.id === targetId);
-      updateDataArray(moveIndexes, toIndex);
-      resetAndSetRowSelection(table, data, moveIds, row => row.id);
+      const newData = structuredClone(data);
+      updateDataArray(moveIndexes, toIndex, newData);
+      resetAndSetRowSelection(table, newData, moveIds, row => row.id);
     };
     const { handleKeyDown } = useTableKeyHandler({
       table,


### PR DESCRIPTION
To use the structuredClone-Object in the DataClassEditor (see this PR: https://github.com/axonivy/dataclass-editor-client/pull/105), I need to extend the updateOrder-function by passing the clonedObject into the function (to demonstrate this i use the structuredClone-Object in the row story "MultiSelectWithReorder", even though it does not really make sense here).