### PR TITLE
XIVY-15631 Add react-hotkeys-hook, with hotkey helper text function

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14218,6 +14218,16 @@
         "react": "^18.3.1"
       }
     },
+    "node_modules/react-hotkeys-hook": {
+      "version": "4.6.1",
+      "resolved": "https://registry.npmjs.org/react-hotkeys-hook/-/react-hotkeys-hook-4.6.1.tgz",
+      "integrity": "sha512-XlZpbKUj9tkfgPgT9gA+1p7Ey6vFIZHttUjPqpTdyT5nqQ8mHL7elxvSbaC+dpSiHUSmr21Ya1mDxBZG3aje4Q==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": ">=16.8.1",
+        "react-dom": ">=16.8.1"
+      }
+    },
     "node_modules/react-is": {
       "version": "18.2.0",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.2.0.tgz",
@@ -17732,6 +17742,7 @@
         "@tanstack/react-table": "8.20.5",
         "clsx": "2.1.1",
         "downshift": "9.0.8",
+        "react-hotkeys-hook": "^4.6.1",
         "react-resizable-panels": "2.1.7",
         "sonner": "1.7.1"
       },

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -32,6 +32,7 @@
     "@tanstack/react-table": "8.20.5",
     "clsx": "2.1.1",
     "downshift": "9.0.8",
+    "react-hotkeys-hook": "^4.6.1",
     "react-resizable-panels": "2.1.7",
     "sonner": "1.7.1"
   },

--- a/packages/components/src/hooks/hotkey.stories.tsx
+++ b/packages/components/src/hooks/hotkey.stories.tsx
@@ -1,0 +1,56 @@
+import { hotkeyText } from '@/utils/hotkey';
+import type { Meta, StoryObj } from '@storybook/react';
+import { useState } from 'react';
+import { useHotkeys } from 'react-hotkeys-hook';
+
+const meta: Meta = {
+  title: 'Hooks/Hotkey',
+  tags: ['autodocs']
+};
+
+export default meta;
+
+export const Default: StoryObj = {
+  render: () => {
+    const [count, setCount] = useState(0);
+    useHotkeys('mod+alt+n', () => setCount(prevCount => prevCount + 1));
+    const hotkey = hotkeyText('mod+alt+n');
+
+    return (
+      <span>
+        Pressed the <b>{hotkey}</b> key {count} times.
+      </span>
+    );
+  }
+};
+
+export const Scoped: StoryObj = {
+  render: () => {
+    const [count, setCount] = useState(0);
+    const ref = useHotkeys('c', () => setCount(prevCount => prevCount + 1));
+    return (
+      <div ref={ref} tabIndex={-1} style={{ border: '2px solid #9e768f' }}>
+        <h1>Scoped Hotkeys</h1>
+        <p>Focus me, and press c to increment the count</p>
+        <p>Count: {count}</p>
+      </div>
+    );
+  }
+};
+
+export const Global: StoryObj = {
+  render: () => {
+    const [count, setCount] = useState(0);
+    useHotkeys('q', () => setCount(prevCount => prevCount + 1));
+    useHotkeys('w', () => setCount(prevCount => prevCount - 1));
+    return (
+      <>
+        <h1>Global Hotkeys</h1>
+        <p>
+          Press <b>q</b> to increment the count, and <b>w</b> to decrement it.
+        </p>
+        <p>Count: {count}</p>
+      </>
+    );
+  }
+};

--- a/packages/components/src/hooks/hotkey.test.tsx
+++ b/packages/components/src/hooks/hotkey.test.tsx
@@ -1,0 +1,42 @@
+import { composeStory } from '@storybook/react';
+import Meta, { Default, Global, Scoped } from '../hooks/hotkey.stories';
+import { act, render, screen, userEvent } from 'test-utils';
+
+const Hotkey = composeStory(Default, Meta);
+const GlobalHotkey = composeStory(Global, Meta);
+const ScopedHotkey = composeStory(Scoped, Meta);
+
+test('hotkey', async () => {
+  userEvent.setup();
+  render(<Hotkey />);
+  const text = screen.getByText(/Pressed the/);
+  expect(text).toHaveTextContent('0 times');
+
+  await act(async () => await userEvent.keyboard('{Control>}{Alt>}{n}'));
+  expect(text).toHaveTextContent('1 times');
+});
+
+test('global', async () => {
+  userEvent.setup();
+  render(<GlobalHotkey />);
+  const text = screen.getByText(/Count:/);
+  expect(text).toHaveTextContent('0');
+  await act(async () => await userEvent.keyboard('q'));
+  expect(text).toHaveTextContent('1');
+  await act(async () => await userEvent.keyboard('w'));
+  expect(text).toHaveTextContent('0');
+  await act(async () => await userEvent.keyboard('w'));
+  expect(text).toHaveTextContent('-1');
+});
+
+test('scoped', async () => {
+  userEvent.setup();
+  render(<ScopedHotkey />);
+  const text = screen.getByText(/Count:/);
+  expect(text).toHaveTextContent('0');
+  await act(async () => await userEvent.keyboard('c'));
+  expect(text).toHaveTextContent('0');
+  await act(async () => await userEvent.click(text));
+  await act(async () => await userEvent.keyboard('c'));
+  expect(text).toHaveTextContent('1');
+});

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -54,6 +54,7 @@ export * from './context/useTheme';
 export * from './utils/array';
 export * from './utils/class-name';
 export * from './utils/equals';
+export * from './utils/hotkey';
 export * from './utils/string';
 export * from './utils/utils';
 export * from './utils/table/table';

--- a/packages/components/src/utils/hotkey.test.tsx
+++ b/packages/components/src/utils/hotkey.test.tsx
@@ -1,0 +1,14 @@
+import { hotkeyText } from '@/utils/hotkey';
+
+test('hotkeyText', () => {
+  expect(hotkeyText('a')).toEqual('a');
+  expect(hotkeyText('ctrl+a')).toEqual('ctrl+a');
+  expect(hotkeyText('shift+a')).toEqual('⇧+a');
+  expect(hotkeyText('alt+a')).toEqual('alt+a');
+  expect(hotkeyText('options+a')).toEqual('options+a');
+  expect(hotkeyText('mod+a')).toEqual('CTRL+a');
+
+  vi.stubGlobal('navigator', { userAgent: 'Mac' });
+  expect(hotkeyText('mod+a')).toEqual('⌘+a');
+  expect(hotkeyText('mod+shift+a')).toEqual('⌘+⇧+a');
+});

--- a/packages/components/src/utils/hotkey.ts
+++ b/packages/components/src/utils/hotkey.ts
@@ -1,0 +1,10 @@
+const isMac = () => window.navigator.userAgent.indexOf('Mac') !== -1;
+
+type ModKey = '⌘' | 'CTRL';
+
+const modKey = (): ModKey => (isMac() ? '⌘' : 'CTRL');
+
+export const MOD_KEY = modKey();
+export const IS_MAC = isMac();
+
+export const hotkeyText = (hotkey: string): string => hotkey.replace('mod', modKey()).replace('shift', '⇧');

--- a/packages/components/src/utils/useShortcut.ts
+++ b/packages/components/src/utils/useShortcut.ts
@@ -1,5 +1,8 @@
 import { useCallback, useEffect, useLayoutEffect, useRef } from 'react';
 
+/**
+ * @deprecated use `useHotkeys` from `react-hotkeys-hook` instead. If you want the help text, use the `hotkeyText` helper function.
+ * */
 export const useShortcut = (key: string, callback: () => void, modifiers?: { ctrl?: boolean; alt?: boolean; shift?: boolean }) => {
   const callbackRef = useRef(callback);
   useLayoutEffect(() => {


### PR DESCRIPTION
- Deprecate useShortcut hook
- Add react-hotkeys-hook lib
- Add hotkeyText utility function

master: https://github.com/axonivy/ui-components/pull/218