### PR TITLE
XIVY-13545 Add poss. to configure delete-key behaviour on row table

### DIFF
--- a/packages/components/src/components/common/table/hooks/hooks.tsx
+++ b/packages/components/src/components/common/table/hooks/hooks.tsx
@@ -146,6 +146,11 @@ interface KeyHandlerOptions<TData> {
   resetSelectionOnTab?: boolean;
 }
 
+export interface KeyDownOptions<TData> {
+  onEnterAction?: (row: Row<TData>) => void;
+  onDeleteAction?: (row: Row<TData>) => void;
+}
+
 interface TableKeyboardHandlerProps<TData> {
   table: Table<TData>;
   data: Array<TData>;
@@ -155,14 +160,15 @@ interface TableKeyboardHandlerProps<TData> {
 export const useTableKeyHandler = <TData,>({ table, data, options }: TableKeyboardHandlerProps<TData>) => {
   const [rootIndex, setRootIndex] = React.useState<number | undefined>(undefined);
 
-  const handleKeyDown = (event: React.KeyboardEvent<HTMLTableElement>, onEnterAction?: (row: Row<TData>) => void) => {
+  const handleKeyDown = (event: React.KeyboardEvent<HTMLTableElement>, key?: KeyDownOptions<TData>) => {
     const actions: Record<string, () => void> = {
       ArrowUp: () => handleArrowKeyUpDown(event, -1),
       ArrowDown: () => handleArrowKeyUpDown(event, 1),
       ArrowLeft: () => toggleExpand(false, table.getSelectedRowModel().flatRows[0], options?.lazyLoadChildren),
       ArrowRight: () => toggleExpand(true, table.getSelectedRowModel().flatRows[0], options?.lazyLoadChildren),
       Tab: () => options?.resetSelectionOnTab && table.resetRowSelection(),
-      Enter: () => onEnterAction?.(table.getSelectedRowModel().flatRows[0])
+      Enter: () => key?.onEnterAction?.(table.getSelectedRowModel().flatRows[0]),
+      Delete: () => key?.onDeleteAction?.(table.getSelectedRowModel().flatRows[0])
     };
     const action = actions[event.key];
     if (action) {

--- a/packages/components/src/components/common/table/row/row.stories.tsx
+++ b/packages/components/src/components/common/table/row/row.stories.tsx
@@ -8,6 +8,7 @@ import * as React from 'react';
 import { tableData, type Payment } from '../data';
 import { arraymove, arrayMoveMultiple, indexOf } from '@/utils/array';
 import { resetAndSetRowSelection } from '@/utils/table/table';
+import { toast, Toaster } from 'sonner';
 
 const meta: Meta<typeof Table> = {
   title: 'Common/Table/Row',
@@ -275,37 +276,47 @@ export const MultiSelectWithReorder: Story = {
     });
 
     return (
-      <Table onKeyDown={handleKeyDown}>
-        <TableHeader>
-          {table.getHeaderGroups().map(headerGroup => (
-            <TableRow key={headerGroup.id}>
-              {headerGroup.headers.map(header => (
-                <TableHead key={header.id} colSpan={header.colSpan}>
-                  {flexRender(header.column.columnDef.header, header.getContext())}
-                </TableHead>
-              ))}
-            </TableRow>
-          ))}
-        </TableHeader>
-        <TableBody>
-          {table.getRowModel().rows.map(row => (
-            <ReorderRow
-              key={row.id}
-              row={row}
-              id={row.original.id}
-              updateOrder={updateOrder}
-              onDrag={!row.getIsSelected() ? () => table.resetRowSelection() : undefined}
-              onClick={event => handleMultiSelectOnRow(row, event)}
-            >
-              {row.getVisibleCells().map(cell => (
-                <TableCell key={cell.id} onClick={() => table.options.meta?.updateData(row.id, cell.column.id, cell.getValue() + '1')}>
-                  {flexRender(cell.column.columnDef.cell, cell.getContext())}
-                </TableCell>
-              ))}
-            </ReorderRow>
-          ))}
-        </TableBody>
-      </Table>
+      <>
+        <Table
+          onKeyDown={e =>
+            handleKeyDown(e, {
+              onEnterAction: () => toast.info('Enter was pressed'),
+              onDeleteAction: () => toast.info('Delete was pressed')
+            })
+          }
+        >
+          <TableHeader>
+            {table.getHeaderGroups().map(headerGroup => (
+              <TableRow key={headerGroup.id}>
+                {headerGroup.headers.map(header => (
+                  <TableHead key={header.id} colSpan={header.colSpan}>
+                    {flexRender(header.column.columnDef.header, header.getContext())}
+                  </TableHead>
+                ))}
+              </TableRow>
+            ))}
+          </TableHeader>
+          <TableBody>
+            {table.getRowModel().rows.map(row => (
+              <ReorderRow
+                key={row.id}
+                row={row}
+                id={row.original.id}
+                updateOrder={updateOrder}
+                onDrag={!row.getIsSelected() ? () => table.resetRowSelection() : undefined}
+                onClick={event => handleMultiSelectOnRow(row, event)}
+              >
+                {row.getVisibleCells().map(cell => (
+                  <TableCell key={cell.id} onClick={() => table.options.meta?.updateData(row.id, cell.column.id, cell.getValue() + '1')}>
+                    {flexRender(cell.column.columnDef.cell, cell.getContext())}
+                  </TableCell>
+                ))}
+              </ReorderRow>
+            ))}
+          </TableBody>
+        </Table>
+        <Toaster />
+      </>
     );
   }
 };

--- a/packages/components/src/components/editor/browser/browser.tsx
+++ b/packages/components/src/components/editor/browser/browser.tsx
@@ -177,7 +177,7 @@ const BrowsersView = ({ browsers, apply, applyBtn }: BrowsersViewProps) => {
                       onChange={browser.globalFilter.setFilter}
                     />
                     <div className={overflowAuto}>
-                      <Table onKeyDown={e => browser.handleKeyDown(e, applyHandler)}>
+                      <Table onKeyDown={e => browser.handleKeyDown(e, { onEnterAction: applyHandler })}>
                         <TableBody>
                           {browser.table.getRowModel().rows?.length ? (
                             browser.table.getRowModel().rows.map(row => (


### PR DESCRIPTION
With this change, I am adding functionality to control not only the Enter key but also the Delete key, allowing you to define what happens when the Delete key is clicked on a row. Additionally, I am introducing a new key object, which will make it much easier to extend in the future if more key functionalities need to be enabled for a row, without having to modify every place where this hook is used.