### PR TITLE
XIVY-15861 Add reset row selection on esc and add tabindex to selectcell

### DIFF
--- a/packages/components/src/components/common/select/select.tsx
+++ b/packages/components/src/components/common/select/select.tsx
@@ -107,7 +107,7 @@ const SelectSeparator = React.forwardRef<
 SelectSeparator.displayName = SelectPrimitive.Separator.displayName;
 
 export type BasicSelectProps = SelectPrimitive.SelectProps &
-  Pick<SelectPrimitive.SelectValueProps, 'placeholder'> & {
+  Pick<SelectPrimitive.SelectValueProps, 'placeholder' | 'tabIndex'> & {
     items: ReadonlyArray<{ value: string; label: string }>;
     emptyItem?: boolean;
     className?: string;

--- a/packages/components/src/components/common/table/footer/footer.tsx
+++ b/packages/components/src/components/common/table/footer/footer.tsx
@@ -4,11 +4,19 @@ import { Button } from '@/components/common/button/button';
 import { Flex } from '@/components/common/flex/flex';
 import { useReadonly } from '@/context/useReadonly';
 
-const TableAddRow = ({ addRow }: { addRow: () => void }) => {
+const TableAddRow = ({ addRow, tabindex }: { addRow: () => void; tabindex?: number }) => {
   const readonly = useReadonly();
   return (
     <Flex alignItems='center' direction='row' gap={1} className={addRowBlock}>
-      <Button icon={IvyIcons.Plus} onClick={addRow} disabled={readonly} className={addRowBtn} variant='outline' aria-label='Add row' />
+      <Button
+        icon={IvyIcons.Plus}
+        onClick={addRow}
+        disabled={readonly}
+        className={addRowBtn}
+        variant='outline'
+        aria-label='Add row'
+        tabIndex={tabindex}
+      />
       <div className={addRowLine} />
     </Flex>
   );

--- a/packages/components/src/components/common/table/hooks/hooks.tsx
+++ b/packages/components/src/components/common/table/hooks/hooks.tsx
@@ -144,6 +144,7 @@ interface KeyHandlerOptions<TData> {
   reorder?: { updateOrder?: (moveIndexes: number[], toIndex: number, data: TData[]) => void; getRowId?: (row: TData) => string };
   lazyLoadChildren?: (row: Row<TData>) => void;
   resetSelectionOnTab?: boolean;
+  resetSelectionOnEscape?: boolean;
 }
 
 interface TableKeyboardHandlerProps<TData> {
@@ -162,7 +163,8 @@ export const useTableKeyHandler = <TData,>({ table, data, options }: TableKeyboa
       ArrowLeft: () => toggleExpand(false, table.getSelectedRowModel().flatRows[0], options?.lazyLoadChildren),
       ArrowRight: () => toggleExpand(true, table.getSelectedRowModel().flatRows[0], options?.lazyLoadChildren),
       Tab: () => options?.resetSelectionOnTab && table.resetRowSelection(),
-      Enter: () => onEnterAction?.(table.getSelectedRowModel().flatRows[0])
+      Enter: () => onEnterAction?.(table.getSelectedRowModel().flatRows[0]),
+      Escape: () => options?.resetSelectionOnEscape && table.resetRowSelection()
     };
     const action = actions[event.key];
     if (action) {

--- a/packages/components/src/components/common/table/row/row.stories.tsx
+++ b/packages/components/src/components/common/table/row/row.stories.tsx
@@ -270,7 +270,8 @@ export const MultiSelectWithReorder: Story = {
       options: {
         multiSelect: true,
         reorder: { updateOrder: updateDataArray, getRowId: row => row.id },
-        resetSelectionOnTab: true
+        resetSelectionOnTab: true,
+        resetSelectionOnEscape: true
       }
     });
 


### PR DESCRIPTION
I hope by adding the possiblity to define a tabindex on SelectCells (all other cells like ComboCell or InputCell do already support this) i can fix the tab bug in edittable with monaco editors