### PR TITLE
Border focused editcell

### DIFF
--- a/packages/components/src/components/common/select/select.tsx
+++ b/packages/components/src/components/common/select/select.tsx
@@ -107,13 +107,23 @@ const SelectSeparator = React.forwardRef<
 SelectSeparator.displayName = SelectPrimitive.Separator.displayName;
 
 export type BasicSelectProps = SelectPrimitive.SelectProps &
-  Pick<SelectPrimitive.SelectValueProps, 'placeholder' | 'tabIndex'> & {
+  Pick<SelectPrimitive.SelectValueProps, 'placeholder' | 'tabIndex' | 'onKeyDown'> & {
     items: ReadonlyArray<{ value: string; label: string }>;
     emptyItem?: boolean;
     className?: string;
   };
 
-const BasicSelect = ({ items, emptyItem, className, placeholder, value, onValueChange, defaultValue, ...props }: BasicSelectProps) => {
+const BasicSelect = ({
+  items,
+  emptyItem,
+  className,
+  placeholder,
+  value,
+  onValueChange,
+  defaultValue,
+  onKeyDown,
+  ...props
+}: BasicSelectProps) => {
   const unknownValue = React.useMemo(() => {
     if (defaultValue && items.find(item => item.value === defaultValue) === undefined) {
       return defaultValue;
@@ -131,9 +141,10 @@ const BasicSelect = ({ items, emptyItem, className, placeholder, value, onValueC
       onValueChange(value);
     }
   };
+
   return (
     <Select value={value} onValueChange={onInternalValueChange} defaultValue={defaultValue} {...props}>
-      <SelectTrigger className={className}>
+      <SelectTrigger className={className} onKeyDown={onKeyDown}>
         <SelectValue placeholder={placeholder} />
       </SelectTrigger>
       <SelectContent>

--- a/packages/components/src/components/common/table/edit/edit.stories.tsx
+++ b/packages/components/src/components/common/table/edit/edit.stories.tsx
@@ -4,7 +4,7 @@ import { useReactTable, getCoreRowModel, flexRender } from '@tanstack/react-tabl
 import * as React from 'react';
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '../table';
 import { tableData, type Payment } from '../data';
-import { SelectRow } from '../row/row';
+import { MessageRow, SelectRow } from '../row/row';
 import { useTableSelect } from '../hooks/hooks';
 import { ComboCell, InputCell, SelectCell } from './edit';
 
@@ -97,12 +97,18 @@ function EditTableDemo() {
         ))}
       </TableHeader>
       <TableBody>
-        {table.getRowModel().rows.map(row => (
-          <SelectRow key={row.id} row={row}>
-            {row.getVisibleCells().map(cell => (
-              <TableCell key={cell.id}>{flexRender(cell.column.columnDef.cell, cell.getContext())}</TableCell>
-            ))}
-          </SelectRow>
+        {table.getRowModel().rows.map((row, index) => (
+          <React.Fragment key={row.id}>
+            <SelectRow row={row}>
+              {row.getVisibleCells().map(cell => (
+                <TableCell key={cell.id}>{flexRender(cell.column.columnDef.cell, cell.getContext())}</TableCell>
+              ))}
+            </SelectRow>
+            <MessageRow
+              message={index === 2 ? { message: 'This is an error', variant: 'error' } : undefined}
+              columnCount={columns.length}
+            />
+          </React.Fragment>
         ))}
       </TableBody>
     </Table>

--- a/packages/components/src/components/common/table/edit/edit.test.tsx
+++ b/packages/components/src/components/common/table/edit/edit.test.tsx
@@ -43,3 +43,92 @@ test('combobox', async () => {
   expect(screen.getAllByRole('row')[1]).toHaveAttribute('data-state', 'selected');
   expect(screen.getAllByRole('combobox')[1]).toHaveValue('123');
 });
+
+const setupTable = async () => {
+  render(<Table />);
+  const rows = screen.getAllByRole('row');
+  const user = userEvent.setup();
+  expect(rows[1]).toHaveAttribute('data-state', 'unselected');
+  await user.click(rows[1]);
+  expect(rows[1]).toHaveAttribute('data-state', 'selected');
+  expect(rows[2]).toHaveAttribute('data-state', 'unselected');
+  return { rows, user };
+};
+
+const selectRowAndNavigate = async (rows: HTMLElement[], user: ReturnType<typeof userEvent.setup>, colIndex: number) => {
+  // Navigate to the correct column
+  for (let i = 0; i <= colIndex; i++) {
+    await user.keyboard('[Tab]');
+  }
+  const tagName = colIndex === 0 ? 'button' : 'input';
+  expect(rows[1].getElementsByTagName('td')[colIndex].getElementsByTagName(tagName)[0]).toHaveFocus();
+
+  // Move down two rows
+  await user.keyboard('[ArrowDown]');
+  await user.keyboard('[ArrowDown]');
+
+  expect(rows[1]).toHaveAttribute('data-state', 'unselected');
+  expect(rows[3]).toHaveAttribute('data-state', 'selected');
+  expect(rows[3].getElementsByTagName('td')[colIndex].getElementsByTagName(tagName)[0]).toHaveFocus();
+
+  // Check jump over disabled select cell
+  await user.keyboard('[ArrowDown]');
+  await user.keyboard('[ArrowDown]');
+  await user.keyboard('[ArrowDown]');
+
+  expect(rows[8]).toHaveAttribute('data-state', 'selected');
+  expect(rows[3]).toHaveAttribute('data-state', 'unselected');
+  expect(rows[8].getElementsByTagName('td')[colIndex].getElementsByTagName(tagName)[0]).toHaveFocus();
+
+  await user.keyboard('[ArrowUp]');
+  expect(rows[6]).toHaveAttribute('data-state', 'selected');
+  expect(rows[8]).toHaveAttribute('data-state', 'unselected');
+  expect(rows[6].getElementsByTagName('td')[colIndex].getElementsByTagName(tagName)[0]).toHaveFocus();
+};
+
+test('keyboard navigation with arrow for select cell', async () => {
+  const { rows, user } = await setupTable();
+  await selectRowAndNavigate(rows, user, 0);
+});
+
+test('keyboard navigation with arrow for input cell', async () => {
+  const { rows, user } = await setupTable();
+  await selectRowAndNavigate(rows, user, 1);
+});
+
+test('keyboard navigation with arrow for combo cell', async () => {
+  const { rows, user } = await setupTable();
+  await selectRowAndNavigate(rows, user, 2);
+});
+
+test('open select menu with enter and nav with arrow', async () => {
+  const { rows, user } = await setupTable();
+  const select = screen.getAllByRole('combobox')[0];
+  expect(select).toHaveTextContent('Success');
+  await user.keyboard('[Tab]');
+  expect(rows[1].getElementsByTagName('td')[0].getElementsByTagName('button')[0]).toHaveFocus();
+  await user.keyboard('[Enter]');
+  expect(screen.getByRole('listbox')).toBeInTheDocument();
+
+  await userEvent.keyboard('[ArrowDown]');
+  await userEvent.keyboard('[Enter]');
+  expect(rows[1]).toHaveAttribute('data-state', 'selected');
+  expect(screen.getAllByRole('combobox')[0]).toHaveTextContent('Failed');
+});
+
+test('open combobox menu with enter and nav with arrow', async () => {
+  const { rows, user } = await setupTable();
+  const combobox = screen.getAllByRole('combobox')[1];
+  expect(combobox).toHaveValue('316');
+  await user.keyboard('[Tab]');
+  await user.keyboard('[Tab]');
+  await user.keyboard('[Tab]');
+  expect(rows[1].getElementsByTagName('td')[2].getElementsByTagName('input')[0]).toHaveFocus();
+  await user.keyboard('[Enter]');
+  expect(screen.getByRole('dialog')).toBeInTheDocument();
+
+  await userEvent.keyboard('[ArrowDown]');
+  await userEvent.keyboard('[Enter]');
+  expect(screen.getAllByRole('row')[1]).toHaveAttribute('data-state', 'selected');
+  expect(screen.getAllByRole('combobox')[1]).toHaveValue('456');
+});

--- a/packages/components/src/components/common/table/edit/edit.tsx
+++ b/packages/components/src/components/common/table/edit/edit.tsx
@@ -33,7 +33,25 @@ type InputCellProps<TData> = InputProps & {
 
 const InputCell = <TData,>({ cell, className, ...props }: InputCellProps<TData>) => {
   const { value, setValue, onBlur, className: editCell } = useEditCell(cell);
-  return <Input value={value} onChange={e => setValue(e.target.value)} onBlur={onBlur} className={cn(editCell, className)} {...props} />;
+  return (
+    <Input
+      value={value}
+      onChange={e => setValue(e.target.value)}
+      onBlur={onBlur}
+      className={cn(editCell, className)}
+      onKeyDown={e => {
+        if (e.key === 'ArrowDown') {
+          e.preventDefault();
+          selectNextPreviousCell(e.currentTarget as HTMLInputElement, cell, 1);
+        }
+        if (e.key === 'ArrowUp') {
+          e.preventDefault();
+          selectNextPreviousCell(e.currentTarget as HTMLInputElement, cell, -1);
+        }
+      }}
+      {...props}
+    />
+  );
 };
 InputCell.displayName = 'InputCell';
 
@@ -43,7 +61,30 @@ type SelectCellProps<TData> = BasicSelectProps & {
 
 const SelectCell = <TData,>({ cell, className, ...props }: SelectCellProps<TData>) => {
   const { value, updateValue, className: editCell } = useEditCell(cell);
-  return <BasicSelect value={value} onValueChange={updateValue} className={cn(editCell, className)} {...props} />;
+  const [open, setOpen] = React.useState(false);
+  return (
+    <BasicSelect
+      value={value}
+      onValueChange={updateValue}
+      className={cn(editCell, className)}
+      onKeyDown={e => {
+        if (e.key === 'ArrowDown') {
+          e.preventDefault();
+          selectNextPreviousCell(e.currentTarget as HTMLButtonElement, cell, 1);
+        }
+        if (e.key === 'ArrowUp') {
+          e.preventDefault();
+          selectNextPreviousCell(e.currentTarget as HTMLButtonElement, cell, -1);
+        }
+        if (e.key === 'Enter') {
+          setOpen(old => !old);
+        }
+      }}
+      onOpenChange={setOpen}
+      open={open}
+      {...props}
+    />
+  );
 };
 SelectCell.displayName = 'SelectCell';
 
@@ -53,8 +94,63 @@ type ComboCellProps<TData, TCombo extends ComboboxOption> = Omit<ComboboxProps<T
 
 const ComboCell = <TData, TCombo extends ComboboxOption>({ cell, className, ...props }: ComboCellProps<TData, TCombo>) => {
   const { value, updateValue, className: editCell } = useEditCell(cell);
-  return <Combobox {...props} value={value} onChange={updateValue} className={cn(editCell, className)} />;
+  return (
+    <Combobox
+      {...props}
+      value={value}
+      onChange={updateValue}
+      className={cn(editCell, className)}
+      onKeyDownExtended={e => {
+        if (e.key === 'ArrowDown' && !document.querySelector('.ui-combobox-menu')) {
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          (e.nativeEvent as any).preventDownshiftDefault = true;
+          selectNextPreviousCell(e.currentTarget as HTMLInputElement, cell, 1);
+        }
+        if (e.key === 'ArrowUp' && !document.querySelector('.ui-combobox-menu')) {
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          (e.nativeEvent as any).preventDownshiftDefault = true;
+          selectNextPreviousCell(e.currentTarget as HTMLInputElement, cell, -1);
+        }
+      }}
+    />
+  );
 };
 ComboCell.displayName = 'ComboCell';
 
 export { InputCell, SelectCell, ComboCell };
+
+export const selectNextPreviousCell = <TData,>(
+  htmlElement: HTMLButtonElement | HTMLInputElement | Element,
+  cell: CellContext<TData, unknown>,
+  direction: -1 | 1
+) => {
+  const focusedCell = htmlElement.closest('td');
+  if (focusedCell && focusedCell instanceof HTMLTableCellElement) {
+    const cellIndex = cell.column.getIndex();
+    const rowIndex = cell.table.getRowModel().flatRows.findIndex(row => row.id === cell.row.id) + 1;
+    const focusNextCell = (rowIndex: number, cellIndex: number) => {
+      const table = focusedCell?.closest('table');
+      if (!table) return;
+      const validRows = Array.from(table.rows).filter(row => !row.classList.contains('ui-message-row'));
+      const nextRow = validRows[rowIndex];
+      if (!nextRow) return;
+
+      const nextCell = nextRow.cells[cellIndex];
+      if (nextCell) {
+        let nextElement;
+        if (htmlElement instanceof HTMLButtonElement) {
+          nextElement = nextCell.querySelector('button');
+        } else {
+          nextElement = nextCell.querySelector('input');
+        }
+
+        if (nextElement && !nextElement.hasAttribute('disabled')) {
+          nextElement.focus();
+        } else {
+          focusNextCell(rowIndex + direction, cellIndex);
+        }
+      }
+    };
+    focusNextCell(rowIndex + direction, cellIndex);
+  }
+};

--- a/packages/components/src/components/common/table/footer/footer.tsx
+++ b/packages/components/src/components/common/table/footer/footer.tsx
@@ -3,8 +3,9 @@ import { addRowLine, addRowBtn, addRowBlock } from './footer.css';
 import { Button } from '@/components/common/button/button';
 import { Flex } from '@/components/common/flex/flex';
 import { useReadonly } from '@/context/useReadonly';
+import type { ButtonHTMLAttributes } from 'react';
 
-const TableAddRow = ({ addRow, tabindex }: { addRow: () => void; tabindex?: number }) => {
+const TableAddRow = ({ addRow, ...props }: { addRow: () => void } & ButtonHTMLAttributes<HTMLButtonElement>) => {
   const readonly = useReadonly();
   return (
     <Flex alignItems='center' direction='row' gap={1} className={addRowBlock}>
@@ -15,7 +16,7 @@ const TableAddRow = ({ addRow, tabindex }: { addRow: () => void; tabindex?: numb
         className={addRowBtn}
         variant='outline'
         aria-label='Add row'
-        tabIndex={tabindex}
+        {...props}
       />
       <div className={addRowLine} />
     </Flex>

--- a/packages/components/src/components/common/table/table.css.ts
+++ b/packages/components/src/components/common/table/table.css.ts
@@ -60,6 +60,9 @@ export const cell = style({
   selectors: {
     [`&:has(.ui-table-edit-cell)`]: {
       padding: 0
+    },
+    [`&:has(.ui-table-edit-cell:focus-visible), &:has(.ui-table-edit-cell:focus-within)`]: {
+      border: `1px solid black`
     }
   }
 });


### PR DESCRIPTION
I had difficulty seeing which cell was focussed (especially with SelectCell). I have now added the focus-border. Unfortunately I couldn't reuse vars.borders.active here, because for some reason the active border is set to the blue backgroundcolour of the row when rows are selected and so you can't see the border.

![borderforfocusededitcell](https://github.com/user-attachments/assets/266a3aad-b981-4541-a8d4-67e5044a375e)
