### PR TITLE
Renovate ignore volta

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,8 +1,6 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": [
-    "local>axonivy/renovate-config:npm"
-  ],
+  "extends": ["local>axonivy/renovate-config:npm"],
+  "ignoreDeps": ["volta"],
   "dependencyDashboardApproval": true
 }
-


### PR DESCRIPTION
Volta is only local dev dependency, ment mainly if you switch to a older branch with an older node version it uses this version.
If we update this, it will cause a new node install for each new node version, so I would keep this manuall for now.
On CI the node version from the docker image is in charge