### PR TITLE
XIVY-16222 Support table key arrow up/down scroll with virtualized rows

### DIFF
--- a/packages/components/src/components/common/table/hooks/hooks.tsx
+++ b/packages/components/src/components/common/table/hooks/hooks.tsx
@@ -1,4 +1,5 @@
 import { SearchInput } from '@/components/common/input/input';
+import { ROW_VIRTUALIZE_INDEX_ATTRIBUTE } from '@/components/common/table/table';
 import { resetAndSetRowSelection, selectRow } from '@/utils/table/table';
 import {
   getFilteredRowModel,
@@ -200,7 +201,7 @@ export const useTableKeyHandler = <TData,>({ table, data, options }: TableKeyboa
       table.resetRowSelection();
       allRows[newReorderIndex].toggleSelected();
       setRootIndex(newReorderIndex);
-      event.currentTarget.rows[newReorderIndex].scrollIntoView({ block: 'center' });
+      scrollToNextRow(event, newReorderIndex);
     }
   };
 
@@ -232,6 +233,20 @@ export const useTableKeyHandler = <TData,>({ table, data, options }: TableKeyboa
   };
 
   return { handleKeyDown };
+};
+
+const scrollToNextRow = (event: React.KeyboardEvent<HTMLTableElement>, newReorderIndex: number) => {
+  let scrollRow = Array.from(event.currentTarget.rows).find(
+    row => row.getAttribute(ROW_VIRTUALIZE_INDEX_ATTRIBUTE) === `${newReorderIndex}`
+  );
+  if (!scrollRow) {
+    scrollRow = event.currentTarget.rows[newReorderIndex];
+  }
+  if (scrollRow) {
+    scrollRow.scrollIntoView({ block: 'center' });
+  } else {
+    event.currentTarget.scrollIntoView({ block: 'end' });
+  }
 };
 
 const toggleExpand = <TData,>(expand: boolean, row?: Row<TData>, loadChildren?: (row: Row<TData>) => void) => {

--- a/packages/components/src/components/common/table/table.tsx
+++ b/packages/components/src/components/common/table/table.tsx
@@ -28,8 +28,14 @@ const TableFooter = React.forwardRef<HTMLTableSectionElement, React.HTMLAttribut
 );
 TableFooter.displayName = 'TableFooter';
 
-const TableRow = React.forwardRef<HTMLTableRowElement, React.HTMLAttributes<HTMLTableRowElement>>(({ className, ...props }, ref) => (
-  <tr ref={ref} className={cn(row, className, 'ui-table-row')} {...props} />
+export const ROW_VIRTUALIZE_INDEX_ATTRIBUTE = 'data-vindex';
+
+type TableRowProps = React.HTMLAttributes<HTMLTableRowElement> & {
+  vindex?: number | string;
+};
+
+const TableRow = React.forwardRef<HTMLTableRowElement, TableRowProps>(({ className, vindex, ...props }, ref) => (
+  <tr ref={ref} className={cn(row, className, 'ui-table-row')} {...{ [ROW_VIRTUALIZE_INDEX_ATTRIBUTE]: vindex }} {...props} />
 ));
 TableRow.displayName = 'TableRow';
 


### PR DESCRIPTION
Support virtualized rows when scroll with arrow keys:

![Screen Recording 2025-03-14 at 12 16 56](https://github.com/user-attachments/assets/f552282b-af15-4077-936c-3c59e9c4f49d)
instead of:
![Screen Recording 2025-03-14 at 12 20 13](https://github.com/user-attachments/assets/b50556f0-a7b3-4283-8109-ca761bb7391b)
