### PR TITLE
XIVY-16716 Fix initial zoom level on initial graph rendering

### DIFF
--- a/packages/graph/src/data/useGraph.ts
+++ b/packages/graph/src/data/useGraph.ts
@@ -45,10 +45,10 @@ const useGraph = ({ graphNodes, options }: GraphProps) => {
       setNodes([...layoutedNodes]);
       setEdges([...layoutedEdges]);
       window.requestAnimationFrame(() => {
-        fitView();
+        fitView({ maxZoom: options?.zoomOnInit?.applyOnLayoutAndFilter ? options.zoomOnInit.level : undefined });
       });
     },
-    [fitView, getEdges, getNodes]
+    [fitView, getEdges, getNodes, options?.zoomOnInit]
   );
 
   const onFilterApply = useCallback(
@@ -63,11 +63,11 @@ const useGraph = ({ graphNodes, options }: GraphProps) => {
       setEdges([...layoutedEdges]);
       setTimeout(() => {
         window.requestAnimationFrame(() => {
-          fitView();
+          fitView({ maxZoom: options?.zoomOnInit?.applyOnLayoutAndFilter ? options.zoomOnInit.level : undefined });
         });
       }, 0);
     },
-    [fitView, graphNodes, options, getNodes]
+    [fitView, getNodes, graphNodes, options]
   );
 
   // Initialize layouted nodes and edges

--- a/packages/graph/src/graph.stories.tsx
+++ b/packages/graph/src/graph.stories.tsx
@@ -22,7 +22,8 @@ export const Default: Story = {
         graphNodes={transformedDataClasses}
         options={{
           filter: true,
-          circleFloatingEdges: true
+          circleFloatingEdges: true,
+          zoomOnInit: { level: 0.75 }
         }}
       />
     );

--- a/packages/graph/src/graph.tsx
+++ b/packages/graph/src/graph.tsx
@@ -1,17 +1,7 @@
 import '@xyflow/react/dist/style.css';
 import './graph.css';
 import { IvyIcons } from '@axonivy/ui-icons';
-import {
-  Background,
-  ConnectionMode,
-  Controls,
-  MiniMap,
-  Panel,
-  ReactFlow,
-  ReactFlowProvider,
-  type Node,
-  type Viewport
-} from '@xyflow/react';
+import { Background, ConnectionMode, Controls, MiniMap, Panel, ReactFlow, ReactFlowProvider, type Node } from '@xyflow/react';
 import { BasicSelect, Button, Flex } from '@axonivy/ui-components';
 import { useGraph } from './data/useGraph';
 import GraphCircleFloatingEdge from './edges/graphCircleFloatingEdge';
@@ -47,7 +37,10 @@ export type GraphProps = {
     circleFloatingEdges?: boolean;
     minimap?: boolean;
     controls?: boolean;
-    defaultViewport?: Viewport;
+    zoomOnInit?: {
+      level: number;
+      applyOnLayoutAndFilter?: boolean;
+    };
   };
 };
 
@@ -64,12 +57,12 @@ const GraphRoot = ({ graphNodes, options }: GraphProps) => {
       onNodesChange={onNodesChange}
       onEdgesChange={onEdgesChange}
       proOptions={{ hideAttribution: true }}
-      defaultViewport={options?.defaultViewport}
       onConnect={onConnect}
       nodeTypes={{ custom: GraphNode }}
       edgeTypes={{ floating: options?.circleFloatingEdges ? GraphCircleFloatingEdge : GraphFloatingEdge }}
       connectionMode={ConnectionMode.Loose}
       fitView={true}
+      fitViewOptions={{ maxZoom: options?.zoomOnInit?.level }}
       onNodeDoubleClick={(e, node) => {
         if (options?.filter) {
           onFilterApply(node.id);


### PR DESCRIPTION
The previous approach using defaultViewport didn’t work. This solution does. I also added the option to apply the default zoom when the graph is reordered—either by using the alignment buttons or by double-clicking a node.