### PR TITLE
XIVY-16716 Improve layout of initial rendered graph

### DIFF
--- a/packages/graph/src/data.ts
+++ b/packages/graph/src/data.ts
@@ -56,7 +56,7 @@ export const dataClasses: Array<DataClass> = [
   },
   {
     id: 'order',
-    name: 'Order',
+    name: 'OrderAnotherVeryVeryVeryVeryVeryVeryVeryVeryLongLabel',
     fqName: { long: `${namespace}.Order`, short: 'Order' },
     fields: [
       { name: 'id', type: 'string' },

--- a/packages/graph/src/data/getLayoutedElements.ts
+++ b/packages/graph/src/data/getLayoutedElements.ts
@@ -1,6 +1,7 @@
 import type { GraphNode } from '../graph';
 import Dagre from '@dagrejs/dagre';
 import { type Edge } from '@xyflow/react';
+import { DEFAULT_NODE_HEIGHT, DEFAULT_NODE_WIDTH } from './useGraph';
 
 const dagreGraph = new Dagre.graphlib.Graph().setDefaultEdgeLabel(() => ({}));
 export type Direction = 'TB' | 'LR';
@@ -8,8 +9,8 @@ export type Direction = 'TB' | 'LR';
 export const getLayoutedElements = ({ nodes, edges, direction = 'TB' }: { nodes: GraphNode[]; edges: Edge[]; direction: Direction }) => {
   dagreGraph.nodes().forEach(nodeId => dagreGraph.removeNode(nodeId));
   dagreGraph.edges().forEach(edge => dagreGraph.removeEdge(edge.v, edge.w));
-  let nodeWidth = 172;
-  let nodeHeight = 50;
+  let nodeWidth = DEFAULT_NODE_WIDTH;
+  let nodeHeight = DEFAULT_NODE_HEIGHT;
   dagreGraph.setGraph({ rankdir: direction });
 
   nodes.forEach(node => {
@@ -35,8 +36,8 @@ export const getLayoutedElements = ({ nodes, edges, direction = 'TB' }: { nodes:
     const newNode = {
       ...node,
       position: {
-        x: nodeWithPosition.x - (node.measured?.width ?? 172) / 2,
-        y: nodeWithPosition.y - (node.measured?.height ?? 50) / 2
+        x: nodeWithPosition.x - (node.measured?.width ?? DEFAULT_NODE_WIDTH) / 2,
+        y: nodeWithPosition.y - (node.measured?.height ?? DEFAULT_NODE_HEIGHT) / 2
       }
     };
 

--- a/packages/graph/src/data/useGraph.ts
+++ b/packages/graph/src/data/useGraph.ts
@@ -14,6 +14,10 @@ import {
 import type { NodeData, GraphNode, GraphProps } from '../graph';
 import { getLayoutedElements, type Direction } from './getLayoutedElements';
 
+export const CHAR_WIDTH = 7.5;
+export const DEFAULT_NODE_WIDTH = 172;
+export const DEFAULT_NODE_HEIGHT = 50;
+
 const useGraph = ({ graphNodes, options }: GraphProps) => {
   const [nodes, setNodes] = useState<Node[]>([]);
   const [edges, setEdges] = useState<Edge[]>([]);
@@ -112,6 +116,18 @@ function filterNodesBySelectedNode(graphNodes: Array<NodeData>, selectedNode: st
 
   return filteredNodes;
 }
+const getNodeSize = (node: NodeData, existingNodes: GraphNode[]): { width: number; height: number } => {
+  const measuredSize = existingNodes.find(n => n.id === node.id)?.measured;
+  if (measuredSize && typeof measuredSize.width === 'number' && typeof measuredSize.height === 'number') {
+    return measuredSize as { width: number; height: number };
+  }
+
+  const calculatedWidth = Math.max(node.label.length * CHAR_WIDTH, DEFAULT_NODE_WIDTH);
+  return {
+    width: calculatedWidth,
+    height: DEFAULT_NODE_HEIGHT
+  };
+};
 
 const mapNodesAndEdges = (graphNodes: NodeData[], existingNodes: GraphNode[], options?: GraphProps['options'], selectedNode?: string) => {
   const newNodes: GraphNode[] = graphNodes.map(node => ({
@@ -127,7 +143,7 @@ const mapNodesAndEdges = (graphNodes: NodeData[], existingNodes: GraphNode[], op
         }
       }
     },
-    measured: existingNodes.find(existingNode => existingNode.id === node.id)?.measured,
+    measured: getNodeSize(node, existingNodes),
     type: 'custom'
   }));
 

--- a/packages/graph/src/graph.stories.tsx
+++ b/packages/graph/src/graph.stories.tsx
@@ -21,7 +21,7 @@ export const Default: Story = {
       <Graph
         graphNodes={transformedDataClasses}
         options={{
-          filter: true,
+          filter: { enabled: true },
           circleFloatingEdges: true,
           zoomOnInit: { level: 0.75 }
         }}

--- a/packages/graph/src/graph.tsx
+++ b/packages/graph/src/graph.tsx
@@ -3,7 +3,7 @@ import './graph.css';
 import { IvyIcons } from '@axonivy/ui-icons';
 import { Background, ConnectionMode, Controls, MiniMap, Panel, ReactFlow, ReactFlowProvider, type Node } from '@xyflow/react';
 import { BasicSelect, Button, Flex } from '@axonivy/ui-components';
-import { useGraph } from './data/useGraph';
+import { CHAR_WIDTH, useGraph } from './data/useGraph';
 import GraphCircleFloatingEdge from './edges/graphCircleFloatingEdge';
 import FloatingConnectionLine from './edges/FloatingConnectionLine';
 import GraphFloatingEdge from './edges/graphFloatingEdge';
@@ -33,7 +33,10 @@ export type GraphNode = Node<{ nodeData: NodeData }, 'custom'>;
 export type GraphProps = {
   graphNodes: NodeData[];
   options?: {
-    filter?: boolean;
+    filter?: {
+      enabled: boolean;
+      allLabel?: string;
+    };
     circleFloatingEdges?: boolean;
     minimap?: boolean;
     controls?: boolean;
@@ -49,6 +52,17 @@ const GraphRoot = ({ graphNodes, options }: GraphProps) => {
     graphNodes,
     options
   });
+
+  const selectItems = [
+    { value: 'all', label: options?.filter?.allLabel ?? 'Show all' },
+    ...graphNodes.map(node => ({
+      value: node.id,
+      label: node.label
+    }))
+  ];
+
+  const longestLabelLength = Math.max(...selectItems.map(item => item.label.length));
+  const menuWidth = `${longestLabelLength * CHAR_WIDTH}px`;
 
   return (
     <ReactFlow
@@ -94,18 +108,7 @@ const GraphRoot = ({ graphNodes, options }: GraphProps) => {
       </Panel>
       {options?.filter && (
         <Panel position='top-left'>
-          <BasicSelect
-            value={selectedNode}
-            onValueChange={onFilterApply}
-            items={[
-              { value: 'all', label: 'Show all' },
-              ...graphNodes.map(node => ({
-                value: node.id,
-                label: node.label
-              }))
-            ]}
-            menuWidth='200px'
-          />
+          <BasicSelect value={selectedNode} onValueChange={onFilterApply} items={selectItems} menuWidth={menuWidth} />
         </Panel>
       )}
     </ReactFlow>


### PR DESCRIPTION
Bruno's feedback was that the initially rendered graph didn’t look very polished.
This was because I didn’t know the actual node sizes at the beginning — they only become available afterward. So initially, I set all nodes to a fixed size of 172 x 50. Naturally, this caused some nodes with longer text to be misaligned or poorly positioned.

Now, I'm trying to estimate a more accurate width for each node based on the label length, which works reasonably well. I'm also applying a similar method to calculate the width of the select menu.