### PR TITLE
Revert "XIVY-16846 fix auto focus of browser search"

### DIFF
--- a/packages/components/src/components/editor/browser/browser.tsx
+++ b/packages/components/src/components/editor/browser/browser.tsx
@@ -186,11 +186,7 @@ const BrowsersView = ({ browsers, apply, applyBtn, options }: BrowsersViewProps)
                   <>
                     <SearchInput
                       placeholder={options?.search?.placeholder ?? 'Search'}
-                      // if the browser is used as a dialog in another dialog, the autofocus is not working
-                      // this is a workaround to set the focus automatically in any case
-                      ref={input => {
-                        setTimeout(() => input?.focus(), 0);
-                      }}
+                      autoFocus={true}
                       value={browser.globalFilter.filter}
                       onChange={browser.globalFilter.setFilter}
                     />


### PR DESCRIPTION
This reverts commit e2c8684a74a9f78bc6da9909bfdc13a136a4b625.

Using the supposed workaround breaks the keyboard navigation in the browser because after every selection change in the table the search gets focused again.
Also, I tried to recreate this bug using minimal elements and it the autofocus of an element inside a deep dialog worked.
Therefore, I think there is a problem somewhere we might be able to fix properly.
