### PR TITLE
XIVY-16846 fix: autofocus in nested dialog browser

### DIFF
--- a/packages/components/src/components/editor/browser/browser.test.tsx
+++ b/packages/components/src/components/editor/browser/browser.test.tsx
@@ -1,3 +1,4 @@
+import { Dialog as DialogComponent, DialogContent, DialogTrigger } from '@/components/common/dialog/dialog';
 import { composeStory } from '@storybook/react-vite';
 import { customRender, screen, userEvent, waitFor } from 'test-utils';
 import Meta, { Default, DialogBrowser, DialogBrowserWithTitle } from './browser.stories';
@@ -130,4 +131,21 @@ test('dialog title', async () => {
   await userEvent.click(screen.getByRole('button', { name: 'Browser' }));
   expect(screen.getByRole('dialog')).toBeInTheDocument();
   expect(screen.getByRole('heading', { level: 2 })).toHaveTextContent('Choose a browser...');
+});
+
+test('auto focus works in nested dialog browser', async () => {
+  customRender(
+    <DialogComponent>
+      <DialogTrigger>Open Dialog</DialogTrigger>
+      <DialogContent>
+        <Dialog />
+      </DialogContent>
+    </DialogComponent>
+  );
+  await userEvent.click(screen.getByRole('button', { name: 'Open Dialog' }));
+  await userEvent.click(screen.getByRole('button', { name: 'Browser' }));
+  expect(screen.getByRole('textbox')).toHaveFocus();
+  await userEvent.tab();
+  await userEvent.keyboard('[ArrowDown]');
+  expect(screen.getByRole('textbox')).not.toHaveFocus();
 });

--- a/packages/components/src/components/editor/browser/browser.tsx
+++ b/packages/components/src/components/editor/browser/browser.tsx
@@ -165,6 +165,10 @@ const BrowsersView = ({ browsers, apply, applyBtn, options }: BrowsersViewProps)
     }
     apply(browser.name, result);
   };
+  const searchRef = React.useRef<HTMLInputElement>(null);
+  React.useEffect(() => {
+    setTimeout(() => searchRef.current?.focus(), 0);
+  }, []);
   return (
     <Tabs value={tab} onValueChange={setTab} className={cn(fullHeight, overflowHidden)}>
       <Flex direction='column' gap={3} className={fullHeight}>
@@ -186,7 +190,7 @@ const BrowsersView = ({ browsers, apply, applyBtn, options }: BrowsersViewProps)
                   <>
                     <SearchInput
                       placeholder={options?.search?.placeholder ?? 'Search'}
-                      autoFocus={true}
+                      ref={searchRef}
                       value={browser.globalFilter.filter}
                       onChange={browser.globalFilter.setFilter}
                     />


### PR DESCRIPTION
Handling focus in nested dialogs with portaling seems to be complex and does not necessarily work even according to radix.
This ensures that the autofocus of the search input works properly whether it's in a nested dialog or not.
