### PR TITLE
XIVY-16606 Rethink basic browser

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1201,18 +1201,6 @@
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
     },
-    "node_modules/@eslint/plugin-kit/node_modules/@eslint/core": {
-      "version": "0.15.1",
-      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.15.1.tgz",
-      "integrity": "sha512-bkOp+iumZCCbt1K1CmWf0R9pM5yKpDv+ZXtvSyQpudrI9kuFLp+bM2WOPXImuD/ceQuaa8f5pj93Y7zyECIGNA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@types/json-schema": "^7.0.15"
-      },
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      }
-    },
     "node_modules/@floating-ui/core": {
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.7.0.tgz",

--- a/packages/components/src/components/common/dialog/dialog.stories.tsx
+++ b/packages/components/src/components/common/dialog/dialog.stories.tsx
@@ -1,12 +1,23 @@
 import { Button } from '@/components/common/button/button';
 import { Combobox } from '@/components/common/combobox/combobox';
 import { BasicField } from '@/components/common/field/field';
+import { Flex } from '@/components/common/flex/flex';
 import { Input } from '@/components/common/input/input';
 import { BasicSelect } from '@/components/common/select/select';
 import { Textarea } from '@/components/common/textarea/textarea';
 import { IvyIcons } from '@axonivy/ui-icons';
 import type { Meta, StoryObj } from '@storybook/react-vite';
-import { BasicDialog, BasicDialogContent, Dialog, DialogTrigger } from './dialog';
+import {
+  BasicDialogContent,
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger
+} from './dialog';
 
 const meta: Meta<typeof Dialog> = {
   title: 'Common/Dialog',
@@ -15,19 +26,22 @@ const meta: Meta<typeof Dialog> = {
     modal: true
   }
 };
+
 const title = 'This is our Title';
+
 const description =
   'Lorem Ipsum is simply dummy text of the printing and typesetting industry.' +
   'em Ipsum has been the industrys standard dummy text ever since the 1500s, when an unknown ' +
   'printer took a galley of type and scrambled it to make a type specimen book.';
 
-const ButtonClose = (
-  <Button variant='outline' size='large'>
+const CancelButton = (props: React.ComponentProps<typeof Button>) => (
+  <Button variant='outline' size='large' {...props}>
     Cancel
   </Button>
 );
-const ButtonCustom = (
-  <Button variant='primary' size='large' icon={IvyIcons.Check}>
+
+const SubmitButton = (props: React.ComponentProps<typeof Button>) => (
+  <Button variant='primary' size='large' icon={IvyIcons.Check} {...props}>
     Save
   </Button>
 );
@@ -41,42 +55,55 @@ export default meta;
 type Story = StoryObj<typeof Dialog>;
 
 export const Default: Story = {
-  render: props => {
-    return (
-      <BasicDialog
-        contentProps={{ title, description, buttonClose: ButtonClose, buttonCustom: ButtonCustom }}
-        dialogTrigger={
-          <DialogTrigger asChild>
-            <Button variant={'outline'}>Open Dialog</Button>
-          </DialogTrigger>
-        }
-        {...props}
-      >
-        <BasicField label='Name'>
-          <Input />
-        </BasicField>
-        <BasicField label='Comment'>
-          <Textarea />
-        </BasicField>
-        <BasicField label='Fruit'>
-          <BasicSelect items={fruits} />
-        </BasicField>
-        <BasicField label='Car'>
-          <Combobox value='' onChange={() => {}} options={[{ value: 'bmv' }, { value: 'volvo' }]} />
-        </BasicField>
-      </BasicDialog>
-    );
-  }
+  render: props => (
+    <Dialog {...props}>
+      <DialogTrigger asChild>
+        <Button variant={'outline'}>Open Dialog</Button>
+      </DialogTrigger>
+      <DialogContent>
+        <Flex direction='column' gap={4}>
+          <DialogHeader>
+            <DialogTitle>{title}</DialogTitle>
+            <DialogDescription>{description}</DialogDescription>
+          </DialogHeader>
+
+          <Flex direction='column' gap={2}>
+            <BasicField label='Name'>
+              <Input />
+            </BasicField>
+            <BasicField label='Comment'>
+              <Textarea />
+            </BasicField>
+            <BasicField label='Fruit'>
+              <BasicSelect items={fruits} />
+            </BasicField>
+            <BasicField label='Car'>
+              <Combobox value='' onChange={() => {}} options={[{ value: 'bmv' }, { value: 'volvo' }]} />
+            </BasicField>
+          </Flex>
+
+          <DialogFooter>
+            <DialogClose asChild>
+              <CancelButton />
+            </DialogClose>
+            <DialogClose asChild>
+              <SubmitButton />
+            </DialogClose>
+          </DialogFooter>
+        </Flex>
+      </DialogContent>
+    </Dialog>
+  )
 };
 
 export const WithBasicDialogContent: Story = {
-  render: props => {
-    return (
-      <Dialog>
-        <DialogTrigger asChild>
-          <Button variant={'outline'}>Open Dialog</Button>
-        </DialogTrigger>
-        <BasicDialogContent title={title} description={description} buttonClose={ButtonClose} buttonCustom={ButtonCustom} {...props}>
+  render: props => (
+    <Dialog {...props}>
+      <DialogTrigger asChild>
+        <Button variant={'outline'}>Open Dialog</Button>
+      </DialogTrigger>
+      <DialogContent>
+        <BasicDialogContent title={title} description={description} cancel={<CancelButton />} submit={<SubmitButton />}>
           <BasicField label='Name'>
             <Input />
           </BasicField>
@@ -90,7 +117,7 @@ export const WithBasicDialogContent: Story = {
             <Combobox value='' onChange={() => {}} options={[{ value: 'bmv' }, { value: 'volvo' }]} />
           </BasicField>
         </BasicDialogContent>
-      </Dialog>
-    );
-  }
+      </DialogContent>
+    </Dialog>
+  )
 };

--- a/packages/components/src/components/common/dialog/dialog.test.tsx
+++ b/packages/components/src/components/common/dialog/dialog.test.tsx
@@ -2,10 +2,10 @@ import { composeStory } from '@storybook/react-vite';
 import { customRender, screen, userEvent } from 'test-utils';
 import Meta, { Default } from './dialog.stories';
 
-const BasicDialog = composeStory(Default, Meta);
+const DefaultDialog = composeStory(Default, Meta);
 
 test('BasicDialog', async () => {
-  customRender(<BasicDialog />);
+  customRender(<DefaultDialog />);
   expect(screen.queryByRole('button', { name: 'Cancel' })).not.toBeInTheDocument();
   await userEvent.click(screen.getByRole('button', { name: 'Open Dialog' }));
   expect(screen.getByRole('button', { name: 'Cancel' })).be.toBeInTheDocument();

--- a/packages/components/src/components/common/dialog/dialog.tsx
+++ b/packages/components/src/components/common/dialog/dialog.tsx
@@ -28,9 +28,9 @@ const DialogContent = ({ className, children, ...props }: React.ComponentProps<t
     <DialogOverlay />
     <DialogPrimitive.Content className={cn(content, className, 'ui-dialog-content')} {...props}>
       {children}
-      <DialogPrimitive.Close asChild>
+      <DialogClose asChild>
         <Button icon={IvyIcons.Close} className={contentClose} />
-      </DialogPrimitive.Close>
+      </DialogClose>
     </DialogPrimitive.Content>
   </DialogPortal>
 );
@@ -42,7 +42,7 @@ const DialogHeader = ({ className, ...props }: React.ComponentProps<typeof Flex>
 DialogHeader.displayName = 'DialogHeader';
 
 const DialogFooter = ({ className, ...props }: React.ComponentProps<typeof Flex>) => (
-  <Flex direction='row-reverse' gap={2} className={cn(footer, className, 'ui-dialog-footer')} {...props} />
+  <Flex direction='row' justifyContent='flex-end' gap={2} className={cn(footer, className, 'ui-dialog-footer')} {...props} />
 );
 DialogFooter.displayName = 'DialogFooter';
 
@@ -56,46 +56,47 @@ const DialogDescription = ({ className, ...props }: React.ComponentProps<typeof 
 );
 DialogDescription.displayName = DialogPrimitive.Description.displayName;
 
-type BasicDialoContentProps = React.ComponentProps<typeof DialogPrimitive.Content> & {
+type BasicDialogHeaderProps = {
   title: string;
   description: React.ReactNode;
-  buttonClose?: React.ReactNode;
-  buttonCustom?: React.ReactNode;
 };
 
-const BasicDialogContent = ({ title, description, buttonClose, buttonCustom, children, ...props }: BasicDialoContentProps) => (
-  <DialogContent {...props}>
-    <DialogHeader>
-      <DialogTitle>{title}</DialogTitle>
-      <DialogDescription>{description}</DialogDescription>
-    </DialogHeader>
-    <Flex direction='column' gap={2}>
-      {children}
-    </Flex>
-    <DialogFooter>
-      <DialogClose asChild>{buttonCustom}</DialogClose>
-      <DialogClose asChild>{buttonClose}</DialogClose>
-    </DialogFooter>
-  </DialogContent>
+const BasicDialogHeader = ({ title, description }: BasicDialogHeaderProps) => (
+  <DialogHeader>
+    <DialogTitle>{title}</DialogTitle>
+    <DialogDescription>{description}</DialogDescription>
+  </DialogHeader>
+);
+BasicDialogHeader.displayName = 'BasicDialogHeader';
+
+type BasicDialogFooterProps = {
+  cancel: React.ReactNode;
+  submit: React.ReactNode;
+};
+
+const BasicDialogFooter = ({ cancel, submit }: BasicDialogFooterProps) => (
+  <DialogFooter>
+    <DialogClose asChild>{cancel}</DialogClose>
+    <DialogClose asChild>{submit}</DialogClose>
+  </DialogFooter>
+);
+BasicDialogFooter.displayName = 'BasicDialogFooter';
+
+type BasicDialoContentProps = BasicDialogHeaderProps & BasicDialogFooterProps & React.ComponentProps<typeof Flex>;
+
+const BasicDialogContent = ({ title, description, cancel, submit, ...props }: BasicDialoContentProps) => (
+  <Flex direction='column' gap={4}>
+    <BasicDialogHeader title={title} description={description} />
+    <Flex direction='column' gap={2} {...props} />
+    <BasicDialogFooter submit={submit} cancel={cancel} />
+  </Flex>
 );
 BasicDialogContent.displayName = 'BasicDialogContent';
 
-type BasicDialogProps = React.ComponentProps<typeof DialogPrimitive.Root> & {
-  dialogTrigger?: React.ReactNode;
-  contentProps: BasicDialoContentProps;
-};
-
-const BasicDialog = ({ dialogTrigger, children, contentProps, ...props }: BasicDialogProps) => (
-  <Dialog {...props}>
-    {dialogTrigger}
-    <BasicDialogContent {...contentProps}>{children}</BasicDialogContent>
-  </Dialog>
-);
-BasicDialog.displayName = 'BasicDialog';
-
 export {
-  BasicDialog,
   BasicDialogContent,
+  BasicDialogFooter,
+  BasicDialogHeader,
   Dialog,
   DialogClose,
   DialogContent,

--- a/packages/components/src/components/editor/browser/browser.stories.tsx
+++ b/packages/components/src/components/editor/browser/browser.stories.tsx
@@ -18,8 +18,8 @@ const meta: Meta<typeof BrowsersView> = {
   component: BrowsersView,
   argTypes: {
     apply: { control: false },
-    applyBtn: { control: false },
-    browsers: { control: false }
+    browsers: { control: false },
+    options: { control: false }
   }
 };
 

--- a/packages/components/src/components/editor/browser/browser.tsx
+++ b/packages/components/src/components/editor/browser/browser.tsx
@@ -9,7 +9,7 @@ import { Table, TableBody, TableCell, TableRow } from '@/components/common/table
 import { ExpandableCell } from '@/components/common/table/tree/tree';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/common/tabs/tabs';
 import { cn } from '@/utils/class-name';
-import type { IvyIcons } from '@axonivy/ui-icons';
+import { IvyIcons } from '@axonivy/ui-icons';
 import {
   flexRender,
   getCoreRowModel,
@@ -110,8 +110,6 @@ export type Browser = {
 export type BrowsersViewProps = {
   browsers: Array<Browser>;
   apply: (browserName: string, result?: BrowserResult) => void;
-  /** @deprecated use options instead */
-  applyBtn?: { label?: string; icon?: IvyIcons };
   options?: {
     applyBtn?: { label?: string; icon?: IvyIcons };
     search?: { placeholder?: string };
@@ -124,8 +122,8 @@ function isUseBrowserResult(browser: Browser['browser']): browser is ReturnType<
   return (browser as ReturnType<typeof useBrowser>).table !== undefined;
 }
 
-const BrowsersView = ({ browsers, apply, applyBtn, options }: BrowsersViewProps) => {
-  const applyButton = applyBtn ?? options?.applyBtn;
+const BrowsersView = ({ browsers, apply, options }: BrowsersViewProps) => {
+  const applyButton = options?.applyBtn;
   const [tab, setTab] = React.useState(browsers[0]?.name ?? '');
   const selectedRow = () => {
     const browser = browsers.find(b => b.name === tab)?.browser;
@@ -229,13 +227,13 @@ const BrowsersView = ({ browsers, apply, applyBtn, options }: BrowsersViewProps)
           <BasicCollapsible label={options?.info?.label ?? 'Info'} style={{ maxHeight: 50 }}>
             {infoProvider(selectedRow())}
           </BasicCollapsible>
-          <Flex direction='row' justifyContent='flex-end' gap={1}>
-            <Button aria-label={options?.cancelBtn?.label ?? 'Cancel'} onClick={() => apply(tab)} size='large'>
+          <Flex direction='row' justifyContent='flex-end' gap={2}>
+            <Button aria-label={options?.cancelBtn?.label ?? 'Cancel'} onClick={() => apply(tab)} size='large' variant='outline'>
               {options?.cancelBtn?.label ?? 'Cancel'}
             </Button>
             <Button
               aria-label={applyButton?.label ?? 'Apply'}
-              icon={applyButton?.icon}
+              icon={applyButton?.icon ?? IvyIcons.Check}
               onClick={() => applyHandler()}
               size='large'
               variant='primary'

--- a/packages/components/src/hooks/hotkey.ts
+++ b/packages/components/src/hooks/hotkey.ts
@@ -30,3 +30,17 @@ export const useHotkeyLocalScopes = (scopes: string[]) => {
 
   return { activateLocalScopes, restoreLocalScopes, restorableScopes };
 };
+
+export const useDialogHotkeys = (scopes: string[] = []) => {
+  const [open, setOpen] = useState(false);
+  const { activateLocalScopes, restoreLocalScopes } = useHotkeyLocalScopes(scopes);
+  const onOpenChange = (open: boolean) => {
+    setOpen(open);
+    if (open) {
+      activateLocalScopes();
+    } else {
+      restoreLocalScopes();
+    }
+  };
+  return { open, onOpenChange };
+};


### PR DESCRIPTION
- Remove `BasicBrowser` component
  Enforces wrong implementation, where to much logic lives outside of the `DialogContent`
- Remove `DialogContent` from `BasicDialogContent`
  Enforces wrong implementation, where to much logic lives outside of the `DialogContent`
- `BasicDialogContent` only contains wished structure of a `DialogContent`
- Add `BasicDialogHeader`
  If `BasicDialogContent` is not ideal to use
- Add `BasicDialogFooter`
  If `BasicDialogContent` is not ideal to use